### PR TITLE
fix: private key validation

### DIFF
--- a/projects/portal/src/app/models/cosmos/bank.application.service.ts
+++ b/projects/portal/src/app/models/cosmos/bank.application.service.ts
@@ -39,15 +39,15 @@ export class BankApplicationService {
       return;
     }
 
-    if (!validatePrivateStoredWallet(privateWallet)) {
-      this.snackBar.open('Invalid Wallet info!', 'Close');
+    const privateKey = convertHexStringToUint8Array(privateWallet.privateKey);
+
+    if (privateKey?.length != 32) {
+      this.snackBar.open('Invalid PrivateKey!', 'Close');
       return;
     }
 
-    const privateKey = convertHexStringToUint8Array(privateWallet.privateKey);
-
-    if (!privateKey) {
-      this.snackBar.open('Invalid PrivateKey!', 'Close');
+    if (!validatePrivateStoredWallet(privateWallet)) {
+      this.snackBar.open('Invalid Wallet info!', 'Close');
       return;
     }
 

--- a/projects/portal/src/app/models/cosmos/bank.application.service.ts
+++ b/projects/portal/src/app/models/cosmos/bank.application.service.ts
@@ -40,8 +40,7 @@ export class BankApplicationService {
     }
 
     const privateKey = convertHexStringToUint8Array(privateWallet.privateKey);
-
-    if (privateKey?.length != 32) {
+    if (!privateKey) {
       this.snackBar.open('Invalid PrivateKey!', 'Close');
       return;
     }

--- a/projects/portal/src/app/utils/converter.ts
+++ b/projects/portal/src/app/utils/converter.ts
@@ -5,6 +5,9 @@ export const convertHexStringToUint8Array = (hexString: string): Uint8Array | un
     const hexStringWithNoWhitespace = hexString.replace(/\s+/g, '');
     const buffer = Buffer.from(hexStringWithNoWhitespace, 'hex');
     const uint8Array = Uint8Array.from(buffer);
+    if (uint8Array.length == 0) {
+      return undefined;
+    }
     return uint8Array;
   } catch (error) {
     console.error(error);

--- a/projects/portal/src/app/utils/validater.ts
+++ b/projects/portal/src/app/utils/validater.ts
@@ -5,30 +5,35 @@ import { cosmosclient } from '@cosmos-client/core';
 export const validatePrivateStoredWallet = (
   privateStoredWallet: StoredWallet & { privateKey: string },
 ): boolean => {
-  const cosmosPrivateKey = createCosmosPrivateKeyFromString(
-    privateStoredWallet.key_type,
-    privateStoredWallet.privateKey,
-  );
-  if (cosmosPrivateKey?.bytes().length != 32) {
+  try {
+    const cosmosPrivateKey = createCosmosPrivateKeyFromString(
+      privateStoredWallet.key_type,
+      privateStoredWallet.privateKey,
+    );
+    if (!cosmosPrivateKey) {
+      return false;
+    }
+    const cosmosPublicKey = createCosmosPublicKeyFromString(
+      privateStoredWallet.key_type,
+      privateStoredWallet.public_key,
+    );
+    if (!cosmosPublicKey) {
+      return false;
+    }
+    const matchPrivateKeyAndPublicKey =
+      cosmosPrivateKey.pubKey().bytes().toString() !== cosmosPublicKey.bytes().toString();
+    if (matchPrivateKeyAndPublicKey) {
+      return false;
+    }
+    const matchPublicKeyAndAddress =
+      cosmosclient.AccAddress.fromPublicKey(cosmosPublicKey).toAccAddress().toString() !==
+      privateStoredWallet.address;
+    if (matchPublicKeyAndAddress) {
+      return false;
+    }
+    return true;
+  } catch (error) {
+    console.error(error);
     return false;
   }
-  const cosmosPublicKey = createCosmosPublicKeyFromString(
-    privateStoredWallet.key_type,
-    privateStoredWallet.public_key,
-  );
-  if (!cosmosPublicKey) {
-    return false;
-  }
-  const matchPrivateKeyAndPublicKey =
-    cosmosPrivateKey.pubKey().bytes().toString() !== cosmosPublicKey.bytes().toString();
-  if (matchPrivateKeyAndPublicKey) {
-    return false;
-  }
-  const matchPublicKeyAndAddress =
-    cosmosclient.AccAddress.fromPublicKey(cosmosPublicKey).toAccAddress().toString() !==
-    privateStoredWallet.address;
-  if (matchPublicKeyAndAddress) {
-    return false;
-  }
-  return true;
 };

--- a/projects/portal/src/app/utils/validater.ts
+++ b/projects/portal/src/app/utils/validater.ts
@@ -9,7 +9,7 @@ export const validatePrivateStoredWallet = (
     privateStoredWallet.key_type,
     privateStoredWallet.privateKey,
   );
-  if (!cosmosPrivateKey) {
+  if (cosmosPrivateKey?.bytes().length != 32) {
     return false;
   }
   const cosmosPublicKey = createCosmosPublicKeyFromString(


### PR DESCRIPTION
@YasunoriMATSUOKA 
Please review.

Fixed a code that didn't work as intended when entering the appropriate private key (like 1234).
Currently, it is detected that it is not Uint8Array, but Uint8Array with a length of 0 is returned, 
So, it has been modified to check the length of Uint8Array.