### PR TITLE
fix: if empty validator website, disable website link

### DIFF
--- a/projects/portal/src/app/views/dialogs/delegate/delegate-menu-dialog/delegate-menu-dialog.component.html
+++ b/projects/portal/src/app/views/dialogs/delegate/delegate-menu-dialog/delegate-menu-dialog.component.html
@@ -22,7 +22,9 @@
         selectedValidator?.commission?.commission_rates?.rate | percent
       }}</span>
     </mat-list-item>
-    <ng-container *ngIf="selectedValidator?.description?.website">
+    <ng-container *ngIf="selectedValidator?.description?.website; then exist; else empty">
+    </ng-container>
+    <ng-template #exist>
       <a href="{{ selectedValidator?.description?.website }}" target="_blank">
         <mat-list-item>
           <span class="column-name"> Website </span>
@@ -30,7 +32,14 @@
           <span class="column-value">{{ selectedValidator?.description?.website }}</span>
         </mat-list-item>
       </a>
-    </ng-container>
+    </ng-template>
+    <ng-template #empty>
+      <mat-list-item>
+        <span class="column-name"> Website </span>
+        <span class="flex-auto"></span>
+        <span class="column-value">{{ selectedValidator?.description?.website }}</span>
+      </mat-list-item>
+    </ng-template>
     <ng-container *ngIf="isDelegated">
       <mat-list-item>
         <span class="column-name">Delegated Amount</span>

--- a/projects/portal/src/app/views/dialogs/delegate/delegate-menu-dialog/delegate-menu-dialog.component.html
+++ b/projects/portal/src/app/views/dialogs/delegate/delegate-menu-dialog/delegate-menu-dialog.component.html
@@ -22,13 +22,15 @@
         selectedValidator?.commission?.commission_rates?.rate | percent
       }}</span>
     </mat-list-item>
-    <a href="{{ selectedValidator?.description?.website }}" target="_blank">
-      <mat-list-item>
-        <span class="column-name"> Website </span>
-        <span class="flex-auto"></span>
-        <span class="column-value">{{ selectedValidator?.description?.website }}</span>
-      </mat-list-item>
-    </a>
+    <ng-container *ngIf="selectedValidator?.description?.website">
+      <a href="{{ selectedValidator?.description?.website }}" target="_blank">
+        <mat-list-item>
+          <span class="column-name"> Website </span>
+          <span class="flex-auto"></span>
+          <span class="column-value">{{ selectedValidator?.description?.website }}</span>
+        </mat-list-item>
+      </a>
+    </ng-container>
     <ng-container *ngIf="isDelegated">
       <mat-list-item>
         <span class="column-name">Delegated Amount</span>


### PR DESCRIPTION
# Change
If the Validator is not set website, the web site field is empty and routing to portal top page.
After the merge, the field will not be shown in such case.

## before
![screencapture-localhost-4200-portal-delegate-validators-2022-04-21-12_51_17](https://user-images.githubusercontent.com/29295263/164368567-3948b9a4-2fdc-45ae-97d9-7ccbb566cac6.png)


## after (if validator.website exists, no changed)
![screencapture-localhost-4200-portal-delegate-validators-2022-04-21-12_40_13](https://user-images.githubusercontent.com/29295263/164368351-18f291ae-e3f5-409d-b97b-2f43d1dfef78.png)

