### PR TITLE
fix: delegate dialog to disable redelegate same validator and warn on delegate to an inactive validator

### DIFF
--- a/projects/portal/src/app/app.module.ts
+++ b/projects/portal/src/app/app.module.ts
@@ -7,6 +7,7 @@ import { AppRedelegateFormDialogModule } from './pages/dialogs/delegate/redelega
 import { AppUndelegateFormDialogModule } from './pages/dialogs/delegate/undelegate-form-dialog/undelegate-form-dialog.module';
 import { reducers, metaReducers } from './reducers';
 import { TxFeeConfirmDialogModule } from './views/cosmos/tx-fee-confirm-dialog/tx-fee-confirm-dialog.module';
+import { InactiveValidatorModule } from './views/dialogs/delegate/invalid-validator-confirm-dialog/inactive-validator-confirm-dialog.module';
 import { ConnectWalletCompletedDialogModule } from './views/dialogs/wallets/connect-wallet-completed-dialog/connect-wallet-completed-dialog.module';
 import { ConnectWalletStartDialogModule } from './views/dialogs/wallets/connect-wallet-start-dialog/connect-wallet-start-dialog.module';
 import { UnunifiBackupMnemonicAndPrivateKeyWizardDialogModule } from './views/dialogs/wallets/ununifi/ununifi-backup-mnemonic-and-private-key-wizard-dialog/ununifi-backup-mnemonic-and-private-key-wizard-dialog.module';
@@ -60,6 +61,7 @@ import { LoadingDialogModule } from 'ng-loading-dialog';
     UnunifiSelectCreateImportDialogModule,
     UnunifiSelectWalletDialogModule,
     UnunifiKeyFormDialogModule,
+    InactiveValidatorModule,
     AppDelegateFormDialogModule,
     AppDelegateMenuDialogModule,
     AppRedelegateFormDialogModule,

--- a/projects/portal/src/app/pages/dialogs/delegate/delegate-form-dialog/delegate-form-dialog.component.html
+++ b/projects/portal/src/app/pages/dialogs/delegate/delegate-form-dialog/delegate-form-dialog.component.html
@@ -1,5 +1,6 @@
 <view-delegate-form-dialog
   [currentStoredWallet]="currentStoredWallet$ | async"
+  [validatorsList]="validatorsList$ | async"
   [coins]="coins$ | async"
   [uguuBalance]="uguuBalance$ | async"
   [minimumGasPrices]="minimumGasPrices$ | async"

--- a/projects/portal/src/app/pages/dialogs/delegate/delegate-form-dialog/delegate-form-dialog.component.ts
+++ b/projects/portal/src/app/pages/dialogs/delegate/delegate-form-dialog/delegate-form-dialog.component.ts
@@ -1,5 +1,6 @@
 import { Component, Inject, OnInit } from '@angular/core';
-import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MatDialog, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material/snack-bar';
 import { cosmosclient, proto, rest } from '@cosmos-client/core';
 import { InlineResponse20066Validators } from '@cosmos-client/core/esm/openapi/api';
 import { CosmosSDKService } from 'projects/portal/src/app/models';
@@ -8,6 +9,7 @@ import { StakingApplicationService } from 'projects/portal/src/app/models/cosmos
 import { StoredWallet } from 'projects/portal/src/app/models/wallets/wallet.model';
 import { WalletService } from 'projects/portal/src/app/models/wallets/wallet.service';
 import { DelegateOnSubmitEvent } from 'projects/portal/src/app/views/dialogs/delegate/delegate-form-dialog/delegate-form-dialog.component';
+import { InactiveValidatorConfirmDialogComponent } from 'projects/portal/src/app/views/dialogs/delegate/invalid-validator-confirm-dialog/inactive-validator-confirm-dialog.component';
 import { combineLatest, Observable } from 'rxjs';
 import { filter, map, mergeMap } from 'rxjs/operators';
 
@@ -21,6 +23,7 @@ export class DelegateFormDialogComponent implements OnInit {
   coins$: Observable<proto.cosmos.base.v1beta1.ICoin[] | undefined>;
   uguuBalance$: Observable<string> | undefined;
   minimumGasPrices$: Observable<proto.cosmos.base.v1beta1.ICoin[] | undefined>;
+  validatorsList$: Observable<InlineResponse20066Validators[] | undefined>;
   validator: InlineResponse20066Validators | undefined;
 
   constructor(
@@ -31,8 +34,14 @@ export class DelegateFormDialogComponent implements OnInit {
     private readonly walletService: WalletService,
     private readonly configS: ConfigService,
     private readonly stakingAppService: StakingApplicationService,
+    private readonly snackBar: MatSnackBar,
+    private readonly dialog: MatDialog,
   ) {
     this.validator = data;
+    this.validatorsList$ = this.cosmosSDK.sdk$.pipe(
+      mergeMap((sdk) => rest.staking.validators(sdk.rest)),
+      map((result) => result.data.validators),
+    );
     this.currentStoredWallet$ = this.walletService.currentStoredWallet$;
     const address$ = this.currentStoredWallet$.pipe(
       filter((wallet): wallet is StoredWallet => wallet !== undefined && wallet !== null),
@@ -56,11 +65,33 @@ export class DelegateFormDialogComponent implements OnInit {
   ngOnInit(): void {}
 
   async onSubmit($event: DelegateOnSubmitEvent) {
-    const txHash = await this.stakingAppService.createDelegate(
-      this.validator?.operator_address!,
-      $event.amount,
-      $event.minimumGasPrice,
-    );
-    this.matDialogRef.close(txHash);
+    this.validatorsList$.subscribe(async (valList) => {
+      const validatorStatus = valList?.find(
+        (val) => val.operator_address == this.validator?.operator_address,
+      )?.status;
+      if (validatorStatus != 'BOND_STATUS_BONDED') {
+        const inactiveValidatorResult = await this.dialog
+          .open(InactiveValidatorConfirmDialogComponent, {
+            data: { valAddress: this.validator?.operator_address!, isConfirmed: false },
+          })
+          .afterClosed()
+          .toPromise();
+
+        if (
+          inactiveValidatorResult === undefined ||
+          inactiveValidatorResult.isConfirmed === false
+        ) {
+          this.snackBar.open('Delegate was canceled', undefined, { duration: 6000 });
+          return;
+        }
+      }
+
+      const txHash = await this.stakingAppService.createDelegate(
+        this.validator?.operator_address!,
+        $event.amount,
+        $event.minimumGasPrice,
+      );
+      this.matDialogRef.close(txHash);
+    });
   }
 }

--- a/projects/portal/src/app/pages/dialogs/delegate/delegate-form-dialog/delegate-form-dialog.component.ts
+++ b/projects/portal/src/app/pages/dialogs/delegate/delegate-form-dialog/delegate-form-dialog.component.ts
@@ -65,33 +65,28 @@ export class DelegateFormDialogComponent implements OnInit {
   ngOnInit(): void {}
 
   async onSubmit($event: DelegateOnSubmitEvent) {
-    this.validatorsList$.subscribe(async (valList) => {
-      const validatorStatus = valList?.find(
-        (val) => val.operator_address == this.validator?.operator_address,
-      )?.status;
-      if (validatorStatus != 'BOND_STATUS_BONDED') {
-        const inactiveValidatorResult = await this.dialog
-          .open(InactiveValidatorConfirmDialogComponent, {
-            data: { valAddress: this.validator?.operator_address!, isConfirmed: false },
-          })
-          .afterClosed()
-          .toPromise();
+    const validatorStatus = $event.validatorList.find(
+      (val) => val.operator_address == this.validator?.operator_address,
+    )?.status;
+    if (validatorStatus != 'BOND_STATUS_BONDED') {
+      const inactiveValidatorResult = await this.dialog
+        .open(InactiveValidatorConfirmDialogComponent, {
+          data: { valAddress: this.validator?.operator_address!, isConfirmed: false },
+        })
+        .afterClosed()
+        .toPromise();
 
-        if (
-          inactiveValidatorResult === undefined ||
-          inactiveValidatorResult.isConfirmed === false
-        ) {
-          this.snackBar.open('Delegate was canceled', undefined, { duration: 6000 });
-          return;
-        }
+      if (inactiveValidatorResult === undefined || inactiveValidatorResult.isConfirmed === false) {
+        this.snackBar.open('Delegate was canceled', undefined, { duration: 6000 });
+        return;
       }
+    }
 
-      const txHash = await this.stakingAppService.createDelegate(
-        this.validator?.operator_address!,
-        $event.amount,
-        $event.minimumGasPrice,
-      );
-      this.matDialogRef.close(txHash);
-    });
+    const txHash = await this.stakingAppService.createDelegate(
+      this.validator?.operator_address!,
+      $event.amount,
+      $event.minimumGasPrice,
+    );
+    this.matDialogRef.close(txHash);
   }
 }

--- a/projects/portal/src/app/pages/dialogs/delegate/redelegate-form-dialog/redelegate-form-dialog.component.html
+++ b/projects/portal/src/app/pages/dialogs/delegate/redelegate-form-dialog/redelegate-form-dialog.component.html
@@ -1,5 +1,6 @@
 <view-redelegate-form-dialog
   [validatorsList]="validatorsList$ | async"
+  [validatorsDetailList]="validatorsDetailList$ | async"
   [currentStoredWallet]="currentStoredWallet$ | async"
   [delegations]="delegations$ | async"
   [delegateAmount]="delegateAmount$ | async"

--- a/projects/portal/src/app/pages/dialogs/delegate/redelegate-form-dialog/redelegate-form-dialog.component.ts
+++ b/projects/portal/src/app/pages/dialogs/delegate/redelegate-form-dialog/redelegate-form-dialog.component.ts
@@ -88,34 +88,29 @@ export class RedelegateFormDialogComponent implements OnInit {
   ngOnInit(): void {}
 
   async onSubmit($event: RedelegateOnSubmitEvent) {
-    this.validatorsDetailList$.subscribe(async (valList) => {
-      const validatorStatus = valList?.find(
-        (val) => val.operator_address == $event.destinationValidator,
-      )?.status;
-      if (validatorStatus != 'BOND_STATUS_BONDED') {
-        const inactiveValidatorResult = await this.dialog
-          .open(InactiveValidatorConfirmDialogComponent, {
-            data: { valAddress: $event.destinationValidator, isConfirmed: false },
-          })
-          .afterClosed()
-          .toPromise();
+    const validatorStatus = $event.validatorList.find(
+      (val) => val.operator_address == $event.destinationValidator,
+    )?.status;
+    if (validatorStatus != 'BOND_STATUS_BONDED') {
+      const inactiveValidatorResult = await this.dialog
+        .open(InactiveValidatorConfirmDialogComponent, {
+          data: { valAddress: $event.destinationValidator, isConfirmed: false },
+        })
+        .afterClosed()
+        .toPromise();
 
-        if (
-          inactiveValidatorResult === undefined ||
-          inactiveValidatorResult.isConfirmed === false
-        ) {
-          this.snackBar.open('Delegate was canceled', undefined, { duration: 6000 });
-          return;
-        }
+      if (inactiveValidatorResult === undefined || inactiveValidatorResult.isConfirmed === false) {
+        this.snackBar.open('Delegate was canceled', undefined, { duration: 6000 });
+        return;
       }
+    }
 
-      const txHash = await this.stakingAppService.Redelegate(
-        this.validator?.operator_address!,
-        $event.destinationValidator,
-        $event.amount,
-        $event.minimumGasPrice,
-      );
-      this.matDialogRef.close(txHash);
-    });
+    const txHash = await this.stakingAppService.Redelegate(
+      this.validator?.operator_address!,
+      $event.destinationValidator,
+      $event.amount,
+      $event.minimumGasPrice,
+    );
+    this.matDialogRef.close(txHash);
   }
 }

--- a/projects/portal/src/app/pages/dialogs/delegate/redelegate-form-dialog/redelegate-form-dialog.component.ts
+++ b/projects/portal/src/app/pages/dialogs/delegate/redelegate-form-dialog/redelegate-form-dialog.component.ts
@@ -1,5 +1,6 @@
 import { Component, Inject, OnInit } from '@angular/core';
-import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MatDialog, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material/snack-bar';
 import { cosmosclient, proto, rest } from '@cosmos-client/core';
 import {
   InlineResponse20063,
@@ -10,6 +11,7 @@ import { ConfigService } from 'projects/portal/src/app/models/config.service';
 import { StakingApplicationService } from 'projects/portal/src/app/models/cosmos/staking.application.service';
 import { StoredWallet } from 'projects/portal/src/app/models/wallets/wallet.model';
 import { WalletService } from 'projects/portal/src/app/models/wallets/wallet.service';
+import { InactiveValidatorConfirmDialogComponent } from 'projects/portal/src/app/views/dialogs/delegate/invalid-validator-confirm-dialog/inactive-validator-confirm-dialog.component';
 import { RedelegateOnSubmitEvent } from 'projects/portal/src/app/views/dialogs/delegate/redelegate-form-dialog/redelegate-form-dialog.component';
 import { combineLatest, Observable } from 'rxjs';
 import { filter, map, mergeMap } from 'rxjs/operators';
@@ -20,6 +22,7 @@ import { filter, map, mergeMap } from 'rxjs/operators';
   styleUrls: ['./redelegate-form-dialog.component.css'],
 })
 export class RedelegateFormDialogComponent implements OnInit {
+  validatorsDetailList$: Observable<InlineResponse20066Validators[] | undefined>;
   validatorsList$: Observable<(string | undefined)[] | undefined>;
   currentStoredWallet$: Observable<StoredWallet | null | undefined>;
   delegations$: Observable<InlineResponse20063>;
@@ -37,11 +40,15 @@ export class RedelegateFormDialogComponent implements OnInit {
     private readonly walletService: WalletService,
     private readonly configS: ConfigService,
     private readonly stakingAppService: StakingApplicationService,
+    private readonly snackBar: MatSnackBar,
+    private readonly dialog: MatDialog,
   ) {
     this.validator = data;
-    this.validatorsList$ = this.cosmosSDK.sdk$.pipe(
+    this.validatorsDetailList$ = this.cosmosSDK.sdk$.pipe(
       mergeMap((sdk) => rest.staking.validators(sdk.rest)),
       map((result) => result.data.validators),
+    );
+    this.validatorsList$ = this.validatorsDetailList$.pipe(
       map((validators) => validators?.map((validator) => validator.operator_address)),
     );
     this.currentStoredWallet$ = this.walletService.currentStoredWallet$;
@@ -81,12 +88,34 @@ export class RedelegateFormDialogComponent implements OnInit {
   ngOnInit(): void {}
 
   async onSubmit($event: RedelegateOnSubmitEvent) {
-    const txHash = await this.stakingAppService.Redelegate(
-      this.validator?.operator_address!,
-      $event.destinationValidator,
-      $event.amount,
-      $event.minimumGasPrice,
-    );
-    this.matDialogRef.close(txHash);
+    this.validatorsDetailList$.subscribe(async (valList) => {
+      const validatorStatus = valList?.find(
+        (val) => val.operator_address == $event.destinationValidator,
+      )?.status;
+      if (validatorStatus != 'BOND_STATUS_BONDED') {
+        const inactiveValidatorResult = await this.dialog
+          .open(InactiveValidatorConfirmDialogComponent, {
+            data: { valAddress: $event.destinationValidator, isConfirmed: false },
+          })
+          .afterClosed()
+          .toPromise();
+
+        if (
+          inactiveValidatorResult === undefined ||
+          inactiveValidatorResult.isConfirmed === false
+        ) {
+          this.snackBar.open('Delegate was canceled', undefined, { duration: 6000 });
+          return;
+        }
+      }
+
+      const txHash = await this.stakingAppService.Redelegate(
+        this.validator?.operator_address!,
+        $event.destinationValidator,
+        $event.amount,
+        $event.minimumGasPrice,
+      );
+      this.matDialogRef.close(txHash);
+    });
   }
 }

--- a/projects/portal/src/app/pages/dialogs/delegate/undelegate-form-dialog/undelegate-form-dialog.component.ts
+++ b/projects/portal/src/app/pages/dialogs/delegate/undelegate-form-dialog/undelegate-form-dialog.component.ts
@@ -10,7 +10,7 @@ import { ConfigService } from 'projects/portal/src/app/models/config.service';
 import { StakingApplicationService } from 'projects/portal/src/app/models/cosmos/staking.application.service';
 import { StoredWallet } from 'projects/portal/src/app/models/wallets/wallet.model';
 import { WalletService } from 'projects/portal/src/app/models/wallets/wallet.service';
-import { DelegateOnSubmitEvent } from 'projects/portal/src/app/views/dialogs/delegate/delegate-form-dialog/delegate-form-dialog.component';
+import { UndelegateOnSubmitEvent } from 'projects/portal/src/app/views/dialogs/delegate/undelegate-form-dialog/undelegate-form-dialog.component';
 import { combineLatest, Observable } from 'rxjs';
 import { filter, map, mergeMap } from 'rxjs/operators';
 
@@ -73,7 +73,7 @@ export class UndelegateFormDialogComponent implements OnInit {
 
   ngOnInit(): void {}
 
-  async onSubmit($event: DelegateOnSubmitEvent) {
+  async onSubmit($event: UndelegateOnSubmitEvent) {
     const txHash = await this.stakingAppService.undelegate(
       this.validator?.operator_address!,
       $event.amount,

--- a/projects/portal/src/app/views/dialogs/delegate/delegate-form-dialog/delegate-form-dialog.component.ts
+++ b/projects/portal/src/app/views/dialogs/delegate/delegate-form-dialog/delegate-form-dialog.component.ts
@@ -7,6 +7,7 @@ import { StoredWallet } from 'projects/portal/src/app/models/wallets/wallet.mode
 export type DelegateOnSubmitEvent = {
   amount: proto.cosmos.base.v1beta1.ICoin;
   minimumGasPrice: proto.cosmos.base.v1beta1.ICoin;
+  validatorList: InlineResponse20066Validators[];
 };
 
 @Component({
@@ -17,6 +18,8 @@ export type DelegateOnSubmitEvent = {
 export class DelegateFormDialogComponent implements OnInit {
   @Input()
   currentStoredWallet?: StoredWallet | null;
+  @Input()
+  validatorsList?: InlineResponse20066Validators[] | null;
   @Input()
   coins?: proto.cosmos.base.v1beta1.ICoin[] | null;
   @Input()
@@ -62,11 +65,18 @@ export class DelegateFormDialogComponent implements OnInit {
     if (!this.selectedAmount) {
       return;
     }
-    if (this.selectedGasPrice === undefined) {
+    if (!this.selectedGasPrice) {
+      return;
+    }
+    if (!this.validatorsList) {
       return;
     }
     this.selectedAmount.amount = this.selectedAmount.amount?.toString();
-    this.appSubmit.emit({ amount: this.selectedAmount, minimumGasPrice: this.selectedGasPrice });
+    this.appSubmit.emit({
+      amount: this.selectedAmount,
+      minimumGasPrice: this.selectedGasPrice,
+      validatorList: this.validatorsList,
+    });
   }
 
   onMinimumGasDenomChanged(denom: string): void {

--- a/projects/portal/src/app/views/dialogs/delegate/invalid-validator-confirm-dialog/inactive-validator-confirm-dialog.component.html
+++ b/projects/portal/src/app/views/dialogs/delegate/invalid-validator-confirm-dialog/inactive-validator-confirm-dialog.component.html
@@ -1,0 +1,6 @@
+<mat-dialog-content>
+  <div>{{ data.valAddress }} is inactive now.</div>
+  <div>Are you sure you want to delegate this validator?</div>
+  <button mat-flat-button class="w-2/5" color="primary" (click)="okToSendTx()">OK</button>
+  <button mat-flat-button class="w-2/5" (click)="cancelToSendTx()">Cancel</button>
+</mat-dialog-content>

--- a/projects/portal/src/app/views/dialogs/delegate/invalid-validator-confirm-dialog/inactive-validator-confirm-dialog.component.ts
+++ b/projects/portal/src/app/views/dialogs/delegate/invalid-validator-confirm-dialog/inactive-validator-confirm-dialog.component.ts
@@ -1,0 +1,31 @@
+import { Component, Inject, OnInit } from '@angular/core';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { proto } from '@cosmos-client/core';
+
+@Component({
+  selector: 'app-view-inactive-validator-confirm-dialog',
+  templateUrl: './inactive-validator-confirm-dialog.component.html',
+  styleUrls: ['./inactive-validator-confirm-dialog.component.css'],
+})
+export class InactiveValidatorConfirmDialogComponent implements OnInit {
+  constructor(
+    @Inject(MAT_DIALOG_DATA)
+    public readonly data: {
+      valAddress: string;
+      isConfirmed: boolean;
+    },
+    private readonly dialogRef: MatDialogRef<InactiveValidatorConfirmDialogComponent>,
+  ) {}
+
+  ngOnInit(): void {}
+
+  okToSendTx(): void {
+    this.data.isConfirmed = true;
+    this.dialogRef.close(this.data);
+  }
+
+  cancelToSendTx(): void {
+    this.data.isConfirmed = false;
+    this.dialogRef.close(this.data);
+  }
+}

--- a/projects/portal/src/app/views/dialogs/delegate/invalid-validator-confirm-dialog/inactive-validator-confirm-dialog.module.ts
+++ b/projects/portal/src/app/views/dialogs/delegate/invalid-validator-confirm-dialog/inactive-validator-confirm-dialog.module.ts
@@ -1,0 +1,11 @@
+import { MaterialModule } from '../../../material.module';
+import { InactiveValidatorConfirmDialogComponent } from './inactive-validator-confirm-dialog.component';
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+
+@NgModule({
+  declarations: [InactiveValidatorConfirmDialogComponent],
+  imports: [CommonModule, MaterialModule],
+  exports: [InactiveValidatorConfirmDialogComponent],
+})
+export class InactiveValidatorModule {}

--- a/projects/portal/src/app/views/dialogs/delegate/redelegate-form-dialog/redelegate-form-dialog.component.html
+++ b/projects/portal/src/app/views/dialogs/delegate/redelegate-form-dialog/redelegate-form-dialog.component.html
@@ -116,7 +116,13 @@
     >
     </mat-slider>
 
-    <button mat-flat-button class="w-full" color="accent" [disabled]="formRef.invalid">
+    <button
+      mat-flat-button
+      class="w-full"
+      color="accent"
+      [disabled]="formRef.invalid"
+      [disabled]="selectedValidator == validator?.operator_address"
+    >
       Change Delegate
     </button>
   </form>

--- a/projects/portal/src/app/views/dialogs/delegate/redelegate-form-dialog/redelegate-form-dialog.component.ts
+++ b/projects/portal/src/app/views/dialogs/delegate/redelegate-form-dialog/redelegate-form-dialog.component.ts
@@ -11,6 +11,7 @@ export type RedelegateOnSubmitEvent = {
   destinationValidator: string;
   amount: proto.cosmos.base.v1beta1.ICoin;
   minimumGasPrice: proto.cosmos.base.v1beta1.ICoin;
+  validatorList: InlineResponse20066Validators[];
 };
 
 @Component({
@@ -21,6 +22,8 @@ export type RedelegateOnSubmitEvent = {
 export class RedelegateFormDialogComponent implements OnInit {
   @Input()
   validatorsList?: (string | undefined)[] | null;
+  @Input()
+  validatorsDetailList?: InlineResponse20066Validators[] | null;
   @Input()
   currentStoredWallet?: StoredWallet | null;
   @Input()
@@ -77,7 +80,10 @@ export class RedelegateFormDialogComponent implements OnInit {
     if (!this.selectedAmount) {
       return;
     }
-    if (this.selectedGasPrice === undefined) {
+    if (!this.selectedGasPrice) {
+      return;
+    }
+    if (!this.validatorsDetailList) {
       return;
     }
     this.selectedAmount.amount = this.selectedAmount.amount?.toString();
@@ -85,6 +91,7 @@ export class RedelegateFormDialogComponent implements OnInit {
       destinationValidator: this.selectedValidator,
       amount: this.selectedAmount,
       minimumGasPrice: this.selectedGasPrice,
+      validatorList: this.validatorsDetailList,
     });
   }
 

--- a/projects/portal/src/app/views/dialogs/delegate/undelegate-form-dialog/undelegate-form-dialog.component.ts
+++ b/projects/portal/src/app/views/dialogs/delegate/undelegate-form-dialog/undelegate-form-dialog.component.ts
@@ -1,10 +1,13 @@
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { proto } from '@cosmos-client/core';
-import { InlineResponse20063, InlineResponse20066Validators } from '@cosmos-client/core/esm/openapi';
+import {
+  InlineResponse20063,
+  InlineResponse20066Validators,
+} from '@cosmos-client/core/esm/openapi';
 import * as crypto from 'crypto';
 import { StoredWallet } from 'projects/portal/src/app/models/wallets/wallet.model';
 
-export type DelegateOnSubmitEvent = {
+export type UndelegateOnSubmitEvent = {
   amount: proto.cosmos.base.v1beta1.ICoin;
   minimumGasPrice: proto.cosmos.base.v1beta1.ICoin;
 };
@@ -31,7 +34,7 @@ export class UndelegateFormDialogComponent implements OnInit {
   validator?: InlineResponse20066Validators | null;
 
   @Output()
-  appSubmit: EventEmitter<DelegateOnSubmitEvent>;
+  appSubmit: EventEmitter<UndelegateOnSubmitEvent>;
 
   selectedGasPrice?: proto.cosmos.base.v1beta1.ICoin;
   availableDenoms?: string[];


### PR DESCRIPTION
# Change

- [x] When try redelegate to same validator, disable `change delegate` button
- [x] When delegate to inactive validator, display warning dialog.

## Self redelegate
![screencapture-localhost-4200-portal-delegate-validators-2022-04-21-13_42_30](https://user-images.githubusercontent.com/29295263/164373575-1a28ba23-aec8-4781-8ed4-7203e170a70a.png)

