### PR TITLE
fix: Txs not showing in Dashboard when no txs

### DIFF
--- a/projects/explorer/src/app/pages/dashboard/dashboard.component.html
+++ b/projects/explorer/src/app/pages/dashboard/dashboard.component.html
@@ -9,7 +9,7 @@
   ></view-dashboard>
   <app-txs class="mb-4"></app-txs>
   <div class="flex flex-col lg:flex-row">
-    <app-blocks class="mr-4 lg:w-1/2"></app-blocks>
+    <app-blocks class="mb-4 lg:mr-4 lg:w-1/2"></app-blocks>
     <app-validators class="lg:w-1/2"></app-validators>
   </div>
 </div>

--- a/projects/explorer/src/app/pages/dashboard/txs/txs.component.ts
+++ b/projects/explorer/src/app/pages/dashboard/txs/txs.component.ts
@@ -125,7 +125,7 @@ export class TxsComponent implements OnInit {
             : modifiedPageSize;
 
         if (modifiedPageOffset <= 0 || modifiedPageSize <= 0) {
-          return [];
+          return of([]);
         }
 
         return rest.tx

--- a/projects/explorer/src/app/views/dashboard/dashboard.component.html
+++ b/projects/explorer/src/app/views/dashboard/dashboard.component.html
@@ -1,7 +1,7 @@
 <h2>Dashboard</h2>
 <div class="flex flex-col lg:flex-row">
   <span class="flex-auto"></span>
-  <mat-card class="mr-4 lg:w-1/3" routerLink="/blocks/{{ latestBlockHeight }}">
+  <mat-card class="mb-4 lg:mr-4 lg:w-1/3" routerLink="/blocks/{{ latestBlockHeight }}">
     <mat-card-header>
       <mat-icon mat-card-avatar>widgets</mat-icon>
       <mat-card-title>Height</mat-card-title>
@@ -13,7 +13,7 @@
   </mat-card>
 
   <span class="flex-auto"></span>
-  <mat-card class="mr-4 lg:w-1/3">
+  <mat-card class="mb-4 lg:mr-4 lg:w-1/3">
     <mat-card-header>
       <mat-icon mat-card-avatar color="primary">savings</mat-icon>
       <mat-card-title>Staked</mat-card-title>


### PR DESCRIPTION
# Changes
- Fixed problem with loading screen not ending when there is no tx.
- Improved mobile display

## before
![スクリーンショット 2022-04-25 142340](https://user-images.githubusercontent.com/29295263/165026054-6e99db45-edbd-4758-900b-39e16822d7b2.png)

## after
![スクリーンショット 2022-04-25 142815](https://user-images.githubusercontent.com/29295263/165026064-8798404c-ae8f-418a-ac63-aa42847230d5.png)

