### PR TITLE
fix: connect wallet UI

### DIFF
--- a/projects/portal/src/app/views/dialogs/wallets/connect-wallet-start-dialog/connect-wallet-start-dialog.component.html
+++ b/projects/portal/src/app/views/dialogs/wallets/connect-wallet-start-dialog/connect-wallet-start-dialog.component.html
@@ -1,16 +1,19 @@
 <mat-dialog-content>
   <div class="flex flex-col items-center">
-    <img class="m-6 w-12 h-12" src="assets/favicon.png" alt="UnUniFi logo">
+    <img class="m-6 w-12 h-12" src="assets/favicon.png" alt="UnUniFi logo" />
     <div class="font-bold text-xl m-3">Connect Your Wallet</div>
     <div class="text-base m-3">Start earning high yield on your crypto</div>
     <ng-container *ngFor="let walletOption of walletOptions">
-      <button class="inline-flex justify-between items-center w-full m-3 bg-white" mat-flat-button (click)="onClickButton(walletOption.walletType)">
+      <button
+        class="inline-flex justify-between items-center w-full m-3 bg-white"
+        mat-flat-button
+        (click)="onClickButton(walletOption.walletType)"
+      >
         <div class="inline-flex items-center">
-          <img class="w-6 h-6" src="{{walletOption.logo}}" alt="{{walletOption.name}} logo">
-          <span class="ml-3 text-black">{{walletOption.name}}</span>
+          <img class="w-6 h-6" src="{{ walletOption.logo }}" alt="{{ walletOption.name }} logo" />
+          <span class="mx-3 text-black">{{ walletOption.name }}</span>
+          <mat-icon class="w-6 h-6" color="primary">arrow_forward</mat-icon>
         </div>
-        <span class="flex-auto"></span>
-        <span class="text-black">----------></span>
       </button>
     </ng-container>
   </div>

--- a/projects/portal/src/app/views/toolbar/toolbar.component.html
+++ b/projects/portal/src/app/views/toolbar/toolbar.component.html
@@ -1,5 +1,5 @@
 <div class="inline-flex items-center w-full">
-  <div class="flex-row w-5/6">
+  <div class="flex-row w-11/12">
     <form #form="ngForm" class="text-base mt-4 sm:mt-6">
       <mat-form-field appearance="fill" (submit)="onSubmitSearchResult()" class="w-full">
         <mat-label>Search</mat-label>
@@ -32,8 +32,8 @@
       </mat-form-field>
     </form>
   </div>
-  <button class="flex-row w-1/6" mat-icon-button (click)="onConnectWallet()">
+  <button class="flex-row" mat-button (click)="onConnectWallet()">
     <mat-icon class="ml-3">wallet</mat-icon>
-    <span class="ml-3">Connect Wallet</span>
+    <span class="ml-3 hidden md:inline-block">Connect Wallet</span>
   </button>
 </div>


### PR DESCRIPTION
close #115

# Changes
- Replace `------>` to mat-icon in connect wallet dialog.
- Changed to show only icon (Connect Wallet) on mobile.
![screencapture-localhost-4200-portal-2022-04-25-15_38_31](https://user-images.githubusercontent.com/29295263/165034164-e46a7d11-902b-404e-a99a-8023576d0c71.png)
![スクリーンショット 2022-04-25 150733](https://user-images.githubusercontent.com/29295263/165034173-37a66bcb-8134-48ba-ae85-2b8658a64569.png)

