### PR TITLE
fix: redirect url on portal search bar

### DIFF
--- a/projects/portal/src/app/app.component.ts
+++ b/projects/portal/src/app/app.component.ts
@@ -216,7 +216,8 @@ export class AppComponent implements OnInit {
     } else if (searchResult.type === 'txHash') {
       await this.router.navigate(['txs', searchResult.searchValue]);
     } else if (searchResult.type === 'block') {
-      await this.router.navigate(['explorer/blocks', searchResult.searchValue]);
+      const redirectUrl = `${location.protocol}//${location.host}/explorer/blocks/${searchResult.searchValue}`;
+      window.location.href = redirectUrl;
     }
   }
 


### PR DESCRIPTION
@Senna46, 
cc : @YasunoriMATSUOKA 

Sorry, I made wrong fix. [https://github.com/UnUniFi/web-apps/pull/100/files](https://github.com/UnUniFi/web-apps/pull/100/files)
So fix again, please review.
I ran the portal and explorer with the command `npm run start:all` on the local PC, 
then entered the block number in the search bar in portal, and confirmed that the page transitioned correctly.