### PR TITLE
hotfix: wrong chain id on beta test

### DIFF
--- a/projects/explorer/editions/ununifi/launch/ununifi-beta-test/firebase-hosting/config.js
+++ b/projects/explorer/editions/ununifi/launch/ununifi-beta-test/firebase-hosting/config.js
@@ -11,7 +11,7 @@ const domainCauchyEA = 'ununifi-beta-test-v1.cauchye.net';
 // const domainCauchyEC = 'c.private-test.ununifi.cauchye.net';
 // const domainCauchyED = 'd.private-test.ununifi.cauchye.net';
 
-const chainID = 'ununifi-9-beta-test-v1'
+const chainID = 'ununifi-9-beta-test'
 
 const bech32Prefix = {
   accAddr: 'ununifi',

--- a/projects/portal/editions/ununifi/launch/ununifi-beta-test/firebase-hosting/config.js
+++ b/projects/portal/editions/ununifi/launch/ununifi-beta-test/firebase-hosting/config.js
@@ -11,7 +11,7 @@ const domainCauchyEA = 'ununifi-beta-test-v1.cauchye.net';
 // const domainCauchyEC = 'c.private-test.ununifi.cauchye.net';
 // const domainCauchyED = 'd.private-test.ununifi.cauchye.net';
 
-const chainID = 'ununifi-9-beta-test-v1'
+const chainID = 'ununifi-9-beta-test'
 
 const bech32Prefix = {
   accAddr: 'ununifi',


### PR DESCRIPTION
@mkXultra 
Plz review 🙏

Correct chain-id on beta-test is "ununifi-9-beta-test", but, in config.json, chain-id is miss configured with "ununifi-9-beta-test-v1".
https://ununifi-beta-test-v1.cauchye.net:1318/cosmos/base/tendermint/v1beta1/node_info