### PR TITLE
fix: allow transactions to be executed on account types other than BaseAccount

### DIFF
--- a/projects/portal/src/app/models/cdps/cdp.infrastructure.service.ts
+++ b/projects/portal/src/app/models/cdps/cdp.infrastructure.service.ts
@@ -1,3 +1,4 @@
+import { convertUnknownAccountToBaseAccount } from '../../utils/converter';
 import { SimulatedTxResultResponse } from '../cosmos/tx-common.model';
 import { TxCommonService } from '../cosmos/tx-common.service';
 import { Key } from '../keys/key.model';
@@ -89,8 +90,10 @@ export class CdpInfrastructureService implements ICdpInfrastructure {
       .then((res) => res.data.account && cosmosclient.codec.unpackCosmosAny(res.data.account))
       .catch((_) => undefined);
 
-    if (!(account instanceof proto.cosmos.auth.v1beta1.BaseAccount)) {
-      throw Error('invalid account!');
+    const baseAccount = convertUnknownAccountToBaseAccount(account);
+
+    if (!baseAccount) {
+      throw Error('Unused Account or Unsupported Account Type!');
     }
 
     // build tx
@@ -113,7 +116,7 @@ export class CdpInfrastructureService implements ICdpInfrastructure {
               mode: proto.cosmos.tx.signing.v1beta1.SignMode.SIGN_MODE_DIRECT,
             },
           },
-          sequence: account.sequence,
+          sequence: baseAccount.sequence,
         },
       ],
       fee: {
@@ -124,7 +127,7 @@ export class CdpInfrastructureService implements ICdpInfrastructure {
 
     // sign
     const txBuilder = new cosmosclient.TxBuilder(sdk.rest, txBody, authInfo);
-    const signDocBytes = txBuilder.signDocBytes(account.account_number);
+    const signDocBytes = txBuilder.signDocBytes(baseAccount.account_number);
     txBuilder.addSignature(privKey.sign(signDocBytes));
 
     return txBuilder;
@@ -195,8 +198,10 @@ export class CdpInfrastructureService implements ICdpInfrastructure {
       .then((res) => res.data.account && cosmosclient.codec.unpackCosmosAny(res.data.account))
       .catch((_) => undefined);
 
-    if (!(account instanceof proto.cosmos.auth.v1beta1.BaseAccount)) {
-      throw Error('invalid account!');
+    const baseAccount = convertUnknownAccountToBaseAccount(account);
+
+    if (!baseAccount) {
+      throw Error('Unused Account or Unsupported Account Type!');
     }
 
     const msgDrawDebt = new ununifi.cdp.MsgDrawDebt({
@@ -217,7 +222,7 @@ export class CdpInfrastructureService implements ICdpInfrastructure {
               mode: proto.cosmos.tx.signing.v1beta1.SignMode.SIGN_MODE_DIRECT,
             },
           },
-          sequence: account.sequence,
+          sequence: baseAccount.sequence,
         },
       ],
       fee: {
@@ -228,7 +233,7 @@ export class CdpInfrastructureService implements ICdpInfrastructure {
 
     // sign
     const txBuilder = new cosmosclient.TxBuilder(sdk.rest, txBody, authInfo);
-    const signDocBytes = txBuilder.signDocBytes(account.account_number);
+    const signDocBytes = txBuilder.signDocBytes(baseAccount.account_number);
     txBuilder.addSignature(privKey.sign(signDocBytes));
 
     return txBuilder;
@@ -299,8 +304,10 @@ export class CdpInfrastructureService implements ICdpInfrastructure {
       .then((res) => res.data.account && cosmosclient.codec.unpackCosmosAny(res.data.account))
       .catch((_) => undefined);
 
-    if (!(account instanceof proto.cosmos.auth.v1beta1.BaseAccount)) {
-      throw Error('invalid account!');
+    const baseAccount = convertUnknownAccountToBaseAccount(account);
+
+    if (!baseAccount) {
+      throw Error('Unused Account or Unsupported Account Type!');
     }
 
     const msgRepayDebt = new ununifi.cdp.MsgRepayDebt({
@@ -321,7 +328,7 @@ export class CdpInfrastructureService implements ICdpInfrastructure {
               mode: proto.cosmos.tx.signing.v1beta1.SignMode.SIGN_MODE_DIRECT,
             },
           },
-          sequence: account.sequence,
+          sequence: baseAccount.sequence,
         },
       ],
       fee: {
@@ -332,7 +339,7 @@ export class CdpInfrastructureService implements ICdpInfrastructure {
 
     // sign
     const txBuilder = new cosmosclient.TxBuilder(sdk.rest, txBody, authInfo);
-    const signDocBytes = txBuilder.signDocBytes(account.account_number);
+    const signDocBytes = txBuilder.signDocBytes(baseAccount.account_number);
     txBuilder.addSignature(privKey.sign(signDocBytes));
 
     return txBuilder;
@@ -408,8 +415,10 @@ export class CdpInfrastructureService implements ICdpInfrastructure {
       .then((res) => res.data.account && cosmosclient.codec.unpackCosmosAny(res.data.account))
       .catch((_) => undefined);
 
-    if (!(account instanceof proto.cosmos.auth.v1beta1.BaseAccount)) {
-      throw Error('invalid account!');
+    const baseAccount = convertUnknownAccountToBaseAccount(account);
+
+    if (!baseAccount) {
+      throw Error('Unused Account or Unsupported Account Type!');
     }
 
     // build tx
@@ -432,7 +441,7 @@ export class CdpInfrastructureService implements ICdpInfrastructure {
               mode: proto.cosmos.tx.signing.v1beta1.SignMode.SIGN_MODE_DIRECT,
             },
           },
-          sequence: account.sequence,
+          sequence: baseAccount.sequence,
         },
       ],
       fee: {
@@ -443,7 +452,7 @@ export class CdpInfrastructureService implements ICdpInfrastructure {
 
     // sign
     const txBuilder = new cosmosclient.TxBuilder(sdk.rest, txBody, authInfo);
-    const signDocBytes = txBuilder.signDocBytes(account.account_number);
+    const signDocBytes = txBuilder.signDocBytes(baseAccount.account_number);
     txBuilder.addSignature(privKey.sign(signDocBytes));
 
     return txBuilder;
@@ -519,8 +528,10 @@ export class CdpInfrastructureService implements ICdpInfrastructure {
       .then((res) => res.data.account && cosmosclient.codec.unpackCosmosAny(res.data.account))
       .catch((_) => undefined);
 
-    if (!(account instanceof proto.cosmos.auth.v1beta1.BaseAccount)) {
-      throw Error('invalid account!');
+    const baseAccount = convertUnknownAccountToBaseAccount(account);
+
+    if (!baseAccount) {
+      throw Error('Unused Account or Unsupported Account Type!');
     }
 
     // build tx
@@ -543,7 +554,7 @@ export class CdpInfrastructureService implements ICdpInfrastructure {
               mode: proto.cosmos.tx.signing.v1beta1.SignMode.SIGN_MODE_DIRECT,
             },
           },
-          sequence: account.sequence,
+          sequence: baseAccount.sequence,
         },
       ],
       fee: {
@@ -554,7 +565,7 @@ export class CdpInfrastructureService implements ICdpInfrastructure {
 
     // sign
     const txBuilder = new cosmosclient.TxBuilder(sdk.rest, txBody, authInfo);
-    const signDocBytes = txBuilder.signDocBytes(account.account_number);
+    const signDocBytes = txBuilder.signDocBytes(baseAccount.account_number);
     txBuilder.addSignature(privKey.sign(signDocBytes));
 
     return txBuilder;

--- a/projects/portal/src/app/models/cosmos/gov.service.ts
+++ b/projects/portal/src/app/models/cosmos/gov.service.ts
@@ -1,3 +1,4 @@
+import { convertUnknownAccountToBaseAccount } from '../../utils/converter';
 import { CosmosSDKService } from '../cosmos-sdk.service';
 import { KeyType } from '../keys/key.model';
 import { KeyService } from '../keys/key.service';
@@ -68,17 +69,13 @@ export class GovService {
     // get account info
     const account = await rest.auth
       .account(sdk, fromAddress)
-      .then(
-        (res) =>
-          res.data.account &&
-          (cosmosclient.codec.unpackCosmosAny(
-            res.data.account,
-          ) as proto.cosmos.auth.v1beta1.BaseAccount),
-      )
+      .then((res) => res.data.account && cosmosclient.codec.unpackCosmosAny(res.data.account))
       .catch((_) => undefined);
 
-    if (!(account instanceof proto.cosmos.auth.v1beta1.BaseAccount)) {
-      throw Error('Address not found');
+    const baseAccount = convertUnknownAccountToBaseAccount(account);
+
+    if (!baseAccount) {
+      throw Error('Unused Account or Unsupported Account Type!');
     }
 
     // build tx
@@ -100,7 +97,7 @@ export class GovService {
               mode: proto.cosmos.tx.signing.v1beta1.SignMode.SIGN_MODE_DIRECT,
             },
           },
-          sequence: account.sequence,
+          sequence: baseAccount.sequence,
         },
       ],
       fee: {
@@ -111,7 +108,7 @@ export class GovService {
 
     // sign
     const txBuilder = new cosmosclient.TxBuilder(sdk, txBody, authInfo);
-    const signDocBytes = txBuilder.signDocBytes(account.account_number);
+    const signDocBytes = txBuilder.signDocBytes(baseAccount.account_number);
     txBuilder.addSignature(privKey.sign(signDocBytes));
 
     return txBuilder;
@@ -176,17 +173,13 @@ export class GovService {
     // get account info
     const account = await rest.auth
       .account(sdk, fromAddress)
-      .then(
-        (res) =>
-          res.data.account &&
-          (cosmosclient.codec.unpackCosmosAny(
-            res.data.account,
-          ) as proto.cosmos.auth.v1beta1.BaseAccount),
-      )
+      .then((res) => res.data.account && cosmosclient.codec.unpackCosmosAny(res.data.account))
       .catch((_) => undefined);
 
-    if (!(account instanceof proto.cosmos.auth.v1beta1.BaseAccount)) {
-      throw Error('Address not found');
+    const baseAccount = convertUnknownAccountToBaseAccount(account);
+
+    if (!baseAccount) {
+      throw Error('Unused Account or Unsupported Account Type!');
     }
 
     // build tx
@@ -208,7 +201,7 @@ export class GovService {
               mode: proto.cosmos.tx.signing.v1beta1.SignMode.SIGN_MODE_DIRECT,
             },
           },
-          sequence: account.sequence,
+          sequence: baseAccount.sequence,
         },
       ],
       fee: {
@@ -219,7 +212,7 @@ export class GovService {
 
     // sign
     const txBuilder = new cosmosclient.TxBuilder(sdk, txBody, authInfo);
-    const signDocBytes = txBuilder.signDocBytes(account.account_number);
+    const signDocBytes = txBuilder.signDocBytes(baseAccount.account_number);
     txBuilder.addSignature(privKey.sign(signDocBytes));
 
     return txBuilder;
@@ -284,17 +277,13 @@ export class GovService {
     // get account info
     const account = await rest.auth
       .account(sdk, fromAddress)
-      .then(
-        (res) =>
-          res.data.account &&
-          (cosmosclient.codec.unpackCosmosAny(
-            res.data.account,
-          ) as proto.cosmos.auth.v1beta1.BaseAccount),
-      )
+      .then((res) => res.data.account && cosmosclient.codec.unpackCosmosAny(res.data.account))
       .catch((_) => undefined);
 
-    if (!(account instanceof proto.cosmos.auth.v1beta1.BaseAccount)) {
-      throw Error('Address not found');
+    const baseAccount = convertUnknownAccountToBaseAccount(account);
+
+    if (!baseAccount) {
+      throw Error('Unused Account or Unsupported Account Type!');
     }
 
     // build tx
@@ -316,7 +305,7 @@ export class GovService {
               mode: proto.cosmos.tx.signing.v1beta1.SignMode.SIGN_MODE_DIRECT,
             },
           },
-          sequence: account.sequence,
+          sequence: baseAccount.sequence,
         },
       ],
       fee: {
@@ -327,7 +316,7 @@ export class GovService {
 
     // sign
     const txBuilder = new cosmosclient.TxBuilder(sdk, txBody, authInfo);
-    const signDocBytes = txBuilder.signDocBytes(account.account_number);
+    const signDocBytes = txBuilder.signDocBytes(baseAccount.account_number);
     txBuilder.addSignature(privKey.sign(signDocBytes));
 
     return txBuilder;

--- a/projects/portal/src/app/models/cosmos/staking.service.ts
+++ b/projects/portal/src/app/models/cosmos/staking.service.ts
@@ -1,3 +1,4 @@
+import { convertUnknownAccountToBaseAccount } from '../../utils/converter';
 import { createCosmosPrivateKeyFromUint8Array } from '../../utils/key';
 import { CosmosSDKService } from '../cosmos-sdk.service';
 import { Key, KeyType } from '../keys/key.model';
@@ -84,8 +85,10 @@ export class StakingService {
       .then((res) => res.data.account && cosmosclient.codec.unpackCosmosAny(res.data.account))
       .catch((_) => undefined);
 
-    if (!(account instanceof proto.cosmos.auth.v1beta1.BaseAccount)) {
-      throw Error('Address not found');
+    const baseAccount = convertUnknownAccountToBaseAccount(account);
+
+    if (!baseAccount) {
+      throw Error('Unused Account or Unsupported Account Type!');
     }
 
     if (createValidatorData.delegator_address !== accAddress.toString()) {
@@ -141,7 +144,7 @@ export class StakingService {
               mode: proto.cosmos.tx.signing.v1beta1.SignMode.SIGN_MODE_DIRECT,
             },
           },
-          sequence: account.sequence,
+          sequence: baseAccount.sequence,
         },
       ],
       fee: {
@@ -152,7 +155,7 @@ export class StakingService {
 
     // sign
     const txBuilder = new cosmosclient.TxBuilder(sdk, txBody, authInfo);
-    const signDocBytes = txBuilder.signDocBytes(account.account_number);
+    const signDocBytes = txBuilder.signDocBytes(baseAccount.account_number);
     txBuilder.addSignature(privKey.sign(signDocBytes));
 
     return txBuilder;
@@ -224,17 +227,13 @@ export class StakingService {
     // get account info
     const account = await rest.auth
       .account(sdk, fromAddress)
-      .then(
-        (res) =>
-          res.data.account &&
-          (cosmosclient.codec.unpackCosmosAny(
-            res.data.account,
-          ) as proto.cosmos.auth.v1beta1.BaseAccount),
-      )
+      .then((res) => res.data.account && cosmosclient.codec.unpackCosmosAny(res.data.account))
       .catch((_) => undefined);
 
-    if (!(account instanceof proto.cosmos.auth.v1beta1.BaseAccount)) {
-      throw Error('Address not found');
+    const baseAccount = convertUnknownAccountToBaseAccount(account);
+
+    if (!baseAccount) {
+      throw Error('Unused Account or Unsupported Account Type!');
     }
 
     // build tx
@@ -256,7 +255,7 @@ export class StakingService {
               mode: proto.cosmos.tx.signing.v1beta1.SignMode.SIGN_MODE_DIRECT,
             },
           },
-          sequence: account.sequence,
+          sequence: baseAccount.sequence,
         },
       ],
       fee: {
@@ -267,7 +266,7 @@ export class StakingService {
 
     // sign
     const txBuilder = new cosmosclient.TxBuilder(sdk, txBody, authInfo);
-    const signDocBytes = txBuilder.signDocBytes(account.account_number);
+    const signDocBytes = txBuilder.signDocBytes(baseAccount.account_number);
     txBuilder.addSignature(privKey.sign(signDocBytes));
 
     return txBuilder;
@@ -344,17 +343,13 @@ export class StakingService {
     // get account info
     const account = await rest.auth
       .account(sdk, fromAddress)
-      .then(
-        (res) =>
-          res.data.account &&
-          (cosmosclient.codec.unpackCosmosAny(
-            res.data.account,
-          ) as proto.cosmos.auth.v1beta1.BaseAccount),
-      )
+      .then((res) => res.data.account && cosmosclient.codec.unpackCosmosAny(res.data.account))
       .catch((_) => undefined);
 
-    if (!(account instanceof proto.cosmos.auth.v1beta1.BaseAccount)) {
-      throw Error('Address not found');
+    const baseAccount = convertUnknownAccountToBaseAccount(account);
+
+    if (!baseAccount) {
+      throw Error('Unused Account or Unsupported Account Type!');
     }
 
     // build tx
@@ -377,7 +372,7 @@ export class StakingService {
               mode: proto.cosmos.tx.signing.v1beta1.SignMode.SIGN_MODE_DIRECT,
             },
           },
-          sequence: account.sequence,
+          sequence: baseAccount.sequence,
         },
       ],
       fee: {
@@ -388,7 +383,7 @@ export class StakingService {
 
     // sign
     const txBuilder = new cosmosclient.TxBuilder(sdk, txBody, authInfo);
-    const signDocBytes = txBuilder.signDocBytes(account.account_number);
+    const signDocBytes = txBuilder.signDocBytes(baseAccount.account_number);
     txBuilder.addSignature(privKey.sign(signDocBytes));
 
     return txBuilder;
@@ -460,17 +455,13 @@ export class StakingService {
     // get account info
     const account = await rest.auth
       .account(sdk, fromAddress)
-      .then(
-        (res) =>
-          res.data.account &&
-          (cosmosclient.codec.unpackCosmosAny(
-            res.data.account,
-          ) as proto.cosmos.auth.v1beta1.BaseAccount),
-      )
+      .then((res) => res.data.account && cosmosclient.codec.unpackCosmosAny(res.data.account))
       .catch((_) => undefined);
 
-    if (!(account instanceof proto.cosmos.auth.v1beta1.BaseAccount)) {
-      throw Error('Address not found');
+    const baseAccount = convertUnknownAccountToBaseAccount(account);
+
+    if (!baseAccount) {
+      throw Error('Unused Account or Unsupported Account Type!');
     }
 
     // build tx
@@ -492,7 +483,7 @@ export class StakingService {
               mode: proto.cosmos.tx.signing.v1beta1.SignMode.SIGN_MODE_DIRECT,
             },
           },
-          sequence: account.sequence,
+          sequence: baseAccount.sequence,
         },
       ],
       fee: {
@@ -503,7 +494,7 @@ export class StakingService {
 
     // sign
     const txBuilder = new cosmosclient.TxBuilder(sdk, txBody, authInfo);
-    const signDocBytes = txBuilder.signDocBytes(account.account_number);
+    const signDocBytes = txBuilder.signDocBytes(baseAccount.account_number);
     txBuilder.addSignature(privKey.sign(signDocBytes));
 
     return txBuilder;


### PR DESCRIPTION
# Changes
- Other Account Type convert BaseAccount

Function check list
- [x] staking
- [x] gov

sample
```
    const sdk = await this.cosmosSDKService.sdk().then((sdk) => sdk.rest);
    const account = await rest.auth
      .account(sdk, accAddress)
      .then((res) => res.data.account && cosmosclient.codec.unpackCosmosAny(res.data.account))
      .catch((_) => undefined);

    const baseAccount = convertUnknownAccountToBaseAccount(account);

    if (!baseAccount) {
      throw Error('Unused Account or Unsupported Account Type!');
    }
```