### PR TITLE
fix: delete some img when window size is for mobile

### DIFF
--- a/projects/landing-page/src/app/views/home/home.component.css
+++ b/projects/landing-page/src/app/views/home/home.component.css
@@ -66,21 +66,18 @@ a {
   width: 20%;
 }
 .star{
-  display: block !important;
   position: absolute !important;
   left: 5% !important;
   top: 20% !important;
   width: 60px;
 }
 .star2{
-  display: block !important;
   position: absolute !important;
   left: 70% !important;
   top: 7% !important;
   width: 25px;
 }
 .arrows{
-  display: block !important;
   position: absolute !important;
   right: 10% !important;
   bottom: 5% !important;
@@ -170,3 +167,8 @@ footer{
   }
 }
 
+@media screen and (max-width:768px) {
+  .join{
+    background-image:none;
+  }
+}

--- a/projects/landing-page/src/app/views/home/home.component.html
+++ b/projects/landing-page/src/app/views/home/home.component.html
@@ -61,8 +61,8 @@
         >
       </div>
     </div>
-    <img src="assets/images/arrows.png" class="arrows" alt="arrows" />
-    <img src="assets/images/star.png" class="star" alt="star" />
+    <img src="assets/images/arrows.png" class="arrows d-none d-md-block" alt="arrows" />
+    <img src="assets/images/star.png" class="star d-none d-md-block" alt="star" />
     <img src="assets/images/man.png" class="man d-none d-md-block" alt="man" />
   </div>
 
@@ -107,7 +107,7 @@
 
 <section class="joinAndPartners">
   <div class="container join py-5" id="community">
-    <img src="assets/images/star.png" class="star2" alt="star" />
+    <img src="assets/images/star.png" class="star2 d-none d-md-block" alt="star" />
     <h3 class="text-center pt-5">Join UnUniFi Community</h3>
     <div class="col-md-7 col-11 mx-auto pt-5">
       <!--discord-->


### PR DESCRIPTION
@YasunoriMATSUOKA 
[https://github.com/UnUniFi/web-apps/issues/155](https://github.com/UnUniFi/web-apps/issues/155)
Please review.
I fix LP by deketing some images when window size smaller then md ( same as "man.img" )

![image](https://user-images.githubusercontent.com/75844498/167837340-2875172c-9f49-4053-8b8c-4af95d7463c7.png)
