### PR TITLE
feat: metamask successfully sent

### DIFF
--- a/projects/portal/src/app/models/cosmos/tx-common.service.ts
+++ b/projects/portal/src/app/models/cosmos/tx-common.service.ts
@@ -26,6 +26,32 @@ export class TxCommonService {
     private readonly metaMaskService: MetaMaskService,
   ) {}
 
+  canonicalizeAccAddress(address: string) {
+    const canonicalized = address.replace(/\s+/g, '');
+    return cosmosclient.AccAddress.fromString(canonicalized);
+  }
+
+  validateBalanceBeforeSimulation(
+    usageAmount: proto.cosmos.base.v1beta1.ICoin[],
+    minimumGasPrice: proto.cosmos.base.v1beta1.ICoin,
+    balances: proto.cosmos.base.v1beta1.ICoin[],
+  ) {
+    const feeDenom = minimumGasPrice.denom;
+    const simulationFeeAmount = 1;
+    const tempAmountToSend = usageAmount.find((amount) => amount.denom === feeDenom)?.amount;
+    const amountToSend = tempAmountToSend ? parseInt(tempAmountToSend) : 0;
+    const tempBalance = balances.find((coin) => coin.denom === minimumGasPrice.denom)?.amount;
+    const balance = tempBalance ? parseInt(tempBalance) : 0;
+
+    return {
+      feeDenom,
+      amountToSend,
+      balance,
+      simulationFeeAmount,
+      validity: amountToSend + simulationFeeAmount <= balance,
+    };
+  }
+
   async getBaseAccount(
     cosmosPublicKey: cosmosclient.PubKey,
   ): Promise<proto.cosmos.auth.v1beta1.BaseAccount | null | undefined> {

--- a/projects/portal/src/app/models/cosmos/tx-common.service.ts
+++ b/projects/portal/src/app/models/cosmos/tx-common.service.ts
@@ -46,6 +46,25 @@ export class TxCommonService {
     return baseAccount;
   }
 
+  async getBaseAccountFromAddress(
+    address: cosmosclient.AccAddress,
+  ): Promise<proto.cosmos.auth.v1beta1.BaseAccount | null | undefined> {
+    const sdk = await this.cosmosSDK.sdk().then((sdk) => sdk.rest);
+    const account = await rest.auth
+      .account(sdk, address)
+      .then((res) =>
+        cosmosclient.codec.protoJSONToInstance(
+          cosmosclient.codec.castProtoJSONOfProtoAny(res.data?.account),
+        ),
+      )
+      .catch((_) => undefined);
+    const baseAccount = convertUnknownAccountToBaseAccount(account);
+    if (!baseAccount) {
+      throw Error('Unused Account or Unsupported Account Type!');
+    }
+    return baseAccount;
+  }
+
   async buildTxBuilder(
     messages: any[],
     cosmosPublicKey: cosmosclient.PubKey,

--- a/projects/portal/src/app/models/wallets/metamask/metamask.infrastructure.service.ts
+++ b/projects/portal/src/app/models/wallets/metamask/metamask.infrastructure.service.ts
@@ -82,8 +82,7 @@ export class MetaMaskInfrastructureService implements IMetaMaskInfrastructureSer
     if (!cosmosPublicKey) {
       throw Error('Invalid public key!');
     }
-    const addressBytes = new Uint8Array(Buffer.from(ethAddress.slice(2), 'hex'));
-    const accAddress = new cosmosclient.AccAddress(addressBytes);
+    const accAddress = cosmosclient.AccAddress.fromPublicKey(cosmosPublicKey);
     const storedWallet: StoredWallet = {
       id: ethAddress,
       type: WalletType.metaMask,

--- a/projects/portal/src/app/models/wallets/metamask/metamask.infrastructure.service.ts
+++ b/projects/portal/src/app/models/wallets/metamask/metamask.infrastructure.service.ts
@@ -82,7 +82,8 @@ export class MetaMaskInfrastructureService implements IMetaMaskInfrastructureSer
     if (!cosmosPublicKey) {
       throw Error('Invalid public key!');
     }
-    const accAddress = cosmosclient.AccAddress.fromPublicKey(cosmosPublicKey);
+    const addressBytes = new Uint8Array(Buffer.from(ethAddress.slice(2), 'hex'));
+    const accAddress = new cosmosclient.AccAddress(addressBytes);
     const storedWallet: StoredWallet = {
       id: ethAddress,
       type: WalletType.metaMask,


### PR DESCRIPTION
I succeeded to send transaction with metamask in local testnet.
@jununifi @YasunoriMATSUOKA 

Caution: Only bank send is supported. Other tx types need to be modified for using address not calculated by pubkey.