### PR TITLE
fix: Add search bar error handling 

### DIFF
--- a/projects/explorer/src/app/app.component.ts
+++ b/projects/explorer/src/app/app.component.ts
@@ -92,11 +92,16 @@ export class AppComponent implements OnInit {
         }
         try {
           return rest.tendermint.getLatestBlock(sdk.rest).then((res) => {
-            return res.data &&
-              res.data.block?.header?.height &&
-              BigInt(res.data.block?.header?.height) > BigInt(searchBoxInputValue)
-              ? BigInt(res.data.block?.header?.height) > BigInt(searchBoxInputValue)
-              : false;
+            try {
+              return res.data &&
+                res.data.block?.header?.height &&
+                BigInt(res.data.block?.header?.height) > BigInt(searchBoxInputValue)
+                ? BigInt(res.data.block?.header?.height) > BigInt(searchBoxInputValue)
+                : false;
+            }
+            catch (error) {
+              return false;
+            }
           });
         } catch (error) {
           return of(false);
@@ -218,5 +223,5 @@ export class AppComponent implements OnInit {
     this.configS.setCurrentConfig(value);
   }
 
-  ngOnInit() {}
+  ngOnInit() { }
 }

--- a/projects/marketplace/src/app/app.component.ts
+++ b/projects/marketplace/src/app/app.component.ts
@@ -83,11 +83,16 @@ export class AppComponent implements OnInit {
         }
         try {
           return rest.tendermint.getLatestBlock(sdk.rest).then((res) => {
-            return res.data &&
-              res.data.block?.header?.height &&
-              BigInt(res.data.block?.header?.height) > BigInt(searchBoxInputValue)
-              ? BigInt(res.data.block?.header?.height) > BigInt(searchBoxInputValue)
-              : false;
+            try {
+              return res.data &&
+                res.data.block?.header?.height &&
+                BigInt(res.data.block?.header?.height) > BigInt(searchBoxInputValue)
+                ? BigInt(res.data.block?.header?.height) > BigInt(searchBoxInputValue)
+                : false;
+            }
+            catch (error) {
+              return false;
+            }
           });
         } catch (error) {
           return of(false);
@@ -217,5 +222,5 @@ export class AppComponent implements OnInit {
     this.configS.setCurrentConfig(value);
   }
 
-  ngOnInit() {}
+  ngOnInit() { }
 }

--- a/projects/portal/src/app/app.component.ts
+++ b/projects/portal/src/app/app.component.ts
@@ -101,11 +101,16 @@ export class AppComponent implements OnInit {
         }
         try {
           return rest.tendermint.getLatestBlock(sdk.rest).then((res) => {
-            return res.data &&
-              res.data.block?.header?.height &&
-              BigInt(res.data.block?.header?.height) > BigInt(searchBoxInputValue)
-              ? BigInt(res.data.block?.header?.height) > BigInt(searchBoxInputValue)
-              : false;
+            try {
+              return res.data &&
+                res.data.block?.header?.height &&
+                BigInt(res.data.block?.header?.height) > BigInt(searchBoxInputValue)
+                ? BigInt(res.data.block?.header?.height) > BigInt(searchBoxInputValue)
+                : false;
+            }
+            catch (error) {
+              return false;
+            }
           });
         } catch (error) {
           return of(false);
@@ -235,5 +240,5 @@ export class AppComponent implements OnInit {
     this.configS.setCurrentConfig(value);
   }
 
-  ngOnInit() {}
+  ngOnInit() { }
 }


### PR DESCRIPTION
@YasunoriMATSUOKA 

When entering upper case numbers in the search bar at the top, an error occurs when converting BigInt.
There is a` try-catch`, but a deeper nesting error could not be detected.
So I added `try-catch`.

‐ before
![image](https://user-images.githubusercontent.com/75844498/176910058-21f7cb3f-9a7a-4a27-8540-43995b57e68b.png)

‐ after
![image](https://user-images.githubusercontent.com/75844498/176910511-c5198873-adad-4372-b6c1-73a95f460271.png)
