### PR TITLE
fix: typo ununufi at develop branch (alpha-testnet)

### DIFF
--- a/projects/marketplace/editions/ununifi/launch/ununifi-8-private-test/firebase-hosting/config.js
+++ b/projects/marketplace/editions/ununifi/launch/ununifi-8-private-test/firebase-hosting/config.js
@@ -12,7 +12,7 @@ const domainCauchyEC = 'c.private-test.ununifi.cauchye.net';
 const domainCauchyED = 'd.private-test.ununifi.cauchye.net';
 
 const chainID = 'ununifi-8-private-test';
-const chainName = 'UnUnuFi (ununifi-8-private-test)';
+const chainName = 'UnUniFi (ununifi-8-private-test)';
 
 const bech32Prefix = {
   accAddr: 'ununifi',

--- a/projects/marketplace/editions/ununifi/launch/ununifi-9-beta-test-v1/firebase-hosting/config.js
+++ b/projects/marketplace/editions/ununifi/launch/ununifi-9-beta-test-v1/firebase-hosting/config.js
@@ -12,7 +12,7 @@ const domainCauchyEA = 'ununifi-beta-test-v1.cauchye.net';
 // const domainCauchyED = 'd.private-test.ununifi.cauchye.net';
 
 const chainID = 'ununifi-9-beta-test-v1';
-const chainName = 'UnUnuFi (ununifi-9-beta-test-v1)';
+const chainName = 'UnUniFi (ununifi-9-beta-test-v1)';
 
 const bech32Prefix = {
   accAddr: 'ununifi',

--- a/projects/marketplace/editions/ununifi/launch/ununifi-alpha-test/firebase-hosting/config.js
+++ b/projects/marketplace/editions/ununifi/launch/ununifi-alpha-test/firebase-hosting/config.js
@@ -9,7 +9,7 @@ const faucetEuuPort = location.protocol === 'https:' ? 8009 : 8008;
 const domainCauchyEA = 'ununifi-alpha-test-v3.cauchye.net';
 
 const chainID = 'ununifi-alpha-test-v3';
-const chainName = 'UnUnuFi (alpha-test)';
+const chainName = 'UnUniFi (alpha-test)';
 
 const bech32Prefix = {
   accAddr: 'ununifi',

--- a/projects/marketplace/editions/ununifi/launch/ununifi-beta-test/firebase-hosting/config.js
+++ b/projects/marketplace/editions/ununifi/launch/ununifi-beta-test/firebase-hosting/config.js
@@ -12,7 +12,7 @@ const domainCauchyEA = 'ununifi-beta-test-v2.cauchye.net';
 // const domainCauchyED = 'd.private-test.ununifi.cauchye.net';
 
 const chainID = 'ununifi-beta-test-v2';
-const chainName = 'UnUnuFi (beta-test)';
+const chainName = 'UnUniFi (beta-test)';
 
 const bech32Prefix = {
   accAddr: 'ununifi',

--- a/projects/marketplace/editions/ununifi/launch/ununifi-test/firebase-hosting/config.js
+++ b/projects/marketplace/editions/ununifi/launch/ununifi-test/firebase-hosting/config.js
@@ -12,7 +12,7 @@ const domainCauchyEC = 'c.ununifi-test-v1.cauchye.net';
 const domainCauchyED = 'd.ununifi-test-v1.cauchye.net';
 
 const chainID = 'ununifi-test-v1';
-const chainName = 'UnUnuFi (test)';
+const chainName = 'UnUniFi (test)';
 
 const bech32Prefix = {
   accAddr: 'ununifi',

--- a/projects/marketplace/editions/ununifi/launch/ununifi/firebase-hosting/config.js
+++ b/projects/marketplace/editions/ununifi/launch/ununifi/firebase-hosting/config.js
@@ -12,7 +12,7 @@ const domainCauchyEC = 'ununifi.mainnet.lcd-01.neukind.network';
 const domainCauchyED = 'ununifi.mainnet.lcd-02.neukind.network';
 
 const chainID = 'ununifi-test-v2';
-const chainName = 'UnUnuFi';
+const chainName = 'UnUniFi';
 
 const bech32Prefix = {
   accAddr: 'ununifi',

--- a/projects/portal/editions/ununifi/launch/ununifi-8-private-test/firebase-hosting/config.js
+++ b/projects/portal/editions/ununifi/launch/ununifi-8-private-test/firebase-hosting/config.js
@@ -12,7 +12,7 @@ const domainCauchyEC = 'c.private-test.ununifi.cauchye.net';
 const domainCauchyED = 'd.private-test.ununifi.cauchye.net';
 
 const chainID = 'ununifi-8-private-test';
-const chainName = 'UnUnuFi (ununifi-8-private-test)';
+const chainName = 'UnUniFi (ununifi-8-private-test)';
 
 const bech32Prefix = {
   accAddr: 'ununifi',

--- a/projects/portal/editions/ununifi/launch/ununifi-9-beta-test-v1/firebase-hosting/config.js
+++ b/projects/portal/editions/ununifi/launch/ununifi-9-beta-test-v1/firebase-hosting/config.js
@@ -12,7 +12,7 @@ const domainCauchyEA = 'ununifi-beta-test-v1.cauchye.net';
 // const domainCauchyED = 'd.private-test.ununifi.cauchye.net';
 
 const chainID = 'ununifi-9-beta-test-v1';
-const chainName = 'UnUnuFi (ununifi-9-beta-test-v1)';
+const chainName = 'UnUniFi (ununifi-9-beta-test-v1)';
 
 const bech32Prefix = {
   accAddr: 'ununifi',

--- a/projects/portal/editions/ununifi/launch/ununifi-beta-test/firebase-hosting/config.js
+++ b/projects/portal/editions/ununifi/launch/ununifi-beta-test/firebase-hosting/config.js
@@ -12,7 +12,7 @@ const domainCauchyEA = 'ununifi-beta-test-v2.cauchye.net';
 // const domainCauchyED = 'd.private-test.ununifi.cauchye.net';
 
 const chainID = 'ununifi-beta-test-v2';
-const chainName = 'UnUnuFi (beta-test)';
+const chainName = 'UnUniFi (beta-test)';
 
 const bech32Prefix = {
   accAddr: 'ununifi',

--- a/projects/portal/editions/ununifi/launch/ununifi/firebase-hosting/config.js
+++ b/projects/portal/editions/ununifi/launch/ununifi/firebase-hosting/config.js
@@ -12,7 +12,7 @@ const domainCauchyEC = 'ununifi.mainnet.lcd-01.neukind.network';
 const domainCauchyED = 'ununifi.mainnet.lcd-02.neukind.network';
 
 const chainID = 'ununifi-beta-v1';
-const chainName = 'UnUnuFi';
+const chainName = 'UnUniFi';
 
 const bech32Prefix = {
   accAddr: 'ununifi',


### PR DESCRIPTION
@yutaro-elk, cc @KimuraYu45z 

Fixed typo in chain-name.
I searched for `Ununufi` in VCcode and replaced it mechanically.

Since the beta-testnet environment could not be reproduced at Local,
I have confirmed that the chain-name is visible in kepler.

![image](https://user-images.githubusercontent.com/75844498/185404186-711a08af-366a-48e4-b5a6-015a460b40bd.png)

Please, review 🙏 