### PR TITLE
Delegator rewards on Balance page

### DIFF
--- a/projects/portal/src/app/app.module.ts
+++ b/projects/portal/src/app/app.module.ts
@@ -5,6 +5,7 @@ import { AppDelegateFormDialogModule } from './pages/dialogs/delegate/delegate-f
 import { AppDelegateMenuDialogModule } from './pages/dialogs/delegate/delegate-menu-dialog/delegate-menu-dialog.module';
 import { AppRedelegateFormDialogModule } from './pages/dialogs/delegate/redelegate-form-dialog/redelegate-form-dialog.module';
 import { AppUndelegateFormDialogModule } from './pages/dialogs/delegate/undelegate-form-dialog/undelegate-form-dialog.module';
+import { AppWithdrawAllDelegatorRewardFormDialogModule } from './pages/dialogs/delegate/withdraw-all-delegator-reward-form-dialog/withdraw-all-delegator-reward-form-dialog.module';
 import { AppWithdrawDelegatorRewardFormDialogModule } from './pages/dialogs/delegate/withdraw-delegator-reward-form-dialog/withdraw-delegator-reward-form-dialog.module';
 import { AppWithdrawValidatorCommissionFormDialogModule } from './pages/dialogs/delegate/withdraw-validator-commission-form-dialog/withdraw-validator-commission-form-dialog.module';
 import { AppDepositFormDialogModule } from './pages/dialogs/vote/deposit-form-dialog/deposit-form-dialog.module';
@@ -68,6 +69,7 @@ import { LoadingDialogModule } from 'projects/shared/src/lib/components/loading-
     AppRedelegateFormDialogModule,
     AppUndelegateFormDialogModule,
     AppWithdrawDelegatorRewardFormDialogModule,
+    AppWithdrawAllDelegatorRewardFormDialogModule,
     AppWithdrawValidatorCommissionFormDialogModule,
     AppVoteFormDialogModule,
     AppDepositFormDialogModule,

--- a/projects/portal/src/app/models/cosmos/distribution.application.service.ts
+++ b/projects/portal/src/app/models/cosmos/distribution.application.service.ts
@@ -1,3 +1,4 @@
+import { WithdrawAllDelegatorRewardFormDialogComponent } from '../../pages/dialogs/delegate/withdraw-all-delegator-reward-form-dialog/withdraw-all-delegator-reward-form-dialog.component';
 import { WithdrawDelegatorRewardFormDialogComponent } from '../../pages/dialogs/delegate/withdraw-delegator-reward-form-dialog/withdraw-delegator-reward-form-dialog.component';
 import { WithdrawValidatorCommissionFormDialogComponent } from '../../pages/dialogs/delegate/withdraw-validator-commission-form-dialog/withdraw-validator-commission-form-dialog.component';
 import { TxFeeConfirmDialogComponent } from '../../views/cosmos/tx-fee-confirm-dialog/tx-fee-confirm-dialog.component';
@@ -35,6 +36,14 @@ export class DistributionApplicationService {
   ): Promise<void> {
     const txHash = await this.dialog
       .open(WithdrawDelegatorRewardFormDialogComponent, { data: validator })
+      .afterClosed()
+      .toPromise();
+    await this.router.navigate(['txs', txHash]);
+  }
+
+  async openWithdrawAllDelegatorRewardFormDialog(): Promise<void> {
+    const txHash = await this.dialog
+      .open(WithdrawAllDelegatorRewardFormDialogComponent)
       .afterClosed()
       .toPromise();
     await this.router.navigate(['txs', txHash]);

--- a/projects/portal/src/app/pages/balance/balance.component.html
+++ b/projects/portal/src/app/pages/balance/balance.component.html
@@ -6,6 +6,7 @@
   [publicKey]="publicKey$ | async"
   [valAddress]="valAddress$ | async"
   [balances]="balances$ | async"
+  [rewards]="rewards$ | async"
   [faucets]="faucets$ | async"
   [nodeInfo]="nodeInfo$ | async"
 ></view-balance>

--- a/projects/portal/src/app/pages/balance/balance.component.html
+++ b/projects/portal/src/app/pages/balance/balance.component.html
@@ -9,4 +9,5 @@
   [rewards]="rewards$ | async"
   [faucets]="faucets$ | async"
   [nodeInfo]="nodeInfo$ | async"
+  (appWithdrawAllDelegatorReward)="onSubmitWithdrawAllDelegatorReward()"
 ></view-balance>

--- a/projects/portal/src/app/pages/balance/balance.component.ts
+++ b/projects/portal/src/app/pages/balance/balance.component.ts
@@ -2,7 +2,10 @@ import { WalletType } from '../../models/wallets/wallet.model';
 import { BalanceUsecaseService } from './balance.usecase.service';
 import { Component, OnInit } from '@angular/core';
 import cosmosclient from '@cosmos-client/core';
-import { InlineResponse20012 } from '@cosmos-client/core/esm/openapi';
+import {
+  CosmosDistributionV1beta1QueryDelegationTotalRewardsResponse,
+  InlineResponse20012,
+} from '@cosmos-client/core/esm/openapi';
 import { Observable } from 'rxjs';
 
 @Component({
@@ -18,14 +21,17 @@ export class BalanceComponent implements OnInit {
   publicKey$: Observable<string | null | undefined>;
   valAddress$: Observable<string | null | undefined>;
   balances$: Observable<cosmosclient.proto.cosmos.base.v1beta1.ICoin[] | null | undefined>;
+  rewards$: Observable<
+    CosmosDistributionV1beta1QueryDelegationTotalRewardsResponse | null | undefined
+  >;
   faucets$: Observable<
     | {
-      hasFaucet: boolean;
-      faucetURL: string;
-      denom: string;
-      creditAmount: number;
-      maxCredit: number;
-    }[]
+        hasFaucet: boolean;
+        faucetURL: string;
+        denom: string;
+        creditAmount: number;
+        maxCredit: number;
+      }[]
     | undefined
   >;
   nodeInfo$: Observable<InlineResponse20012>;
@@ -37,10 +43,11 @@ export class BalanceComponent implements OnInit {
     this.publicKey$ = this.usecase.publicKey$;
     this.valAddress$ = this.usecase.valAddress$;
     this.balances$ = this.usecase.balances$;
+    this.rewards$ = this.usecase.rewards$;
     this.faucets$ = this.usecase.faucets$;
     this.nodeInfo$ = this.usecase.nodeInfo$;
     this.accountTypeName$ = this.usecase.accountTypeName$;
   }
 
-  ngOnInit(): void { }
+  ngOnInit(): void {}
 }

--- a/projects/portal/src/app/pages/balance/balance.component.ts
+++ b/projects/portal/src/app/pages/balance/balance.component.ts
@@ -1,3 +1,4 @@
+import { DistributionApplicationService } from '../../models/cosmos/distribution.application.service';
 import { WalletType } from '../../models/wallets/wallet.model';
 import { BalanceUsecaseService } from './balance.usecase.service';
 import { Component, OnInit } from '@angular/core';
@@ -36,7 +37,10 @@ export class BalanceComponent implements OnInit {
   >;
   nodeInfo$: Observable<InlineResponse20012>;
 
-  constructor(private usecase: BalanceUsecaseService) {
+  constructor(
+    private usecase: BalanceUsecaseService,
+    private readonly distributionAppService: DistributionApplicationService,
+  ) {
     this.walletId$ = this.usecase.walletId$;
     this.walletType$ = this.usecase.walletType$;
     this.accAddress$ = this.usecase.accAddress$;
@@ -50,4 +54,8 @@ export class BalanceComponent implements OnInit {
   }
 
   ngOnInit(): void {}
+
+  onSubmitWithdrawAllDelegatorReward() {
+    this.distributionAppService.openWithdrawAllDelegatorRewardFormDialog();
+  }
 }

--- a/projects/portal/src/app/pages/balance/balance.usecase.service.ts
+++ b/projects/portal/src/app/pages/balance/balance.usecase.service.ts
@@ -9,7 +9,10 @@ import {
 } from './../../utils/converter';
 import { Injectable } from '@angular/core';
 import cosmosclient from '@cosmos-client/core';
-import { InlineResponse20012 } from '@cosmos-client/core/esm/openapi';
+import {
+  CosmosDistributionV1beta1QueryDelegationTotalRewardsResponse,
+  InlineResponse20012,
+} from '@cosmos-client/core/esm/openapi';
 import { combineLatest, Observable, of } from 'rxjs';
 import { map, mergeMap } from 'rxjs/operators';
 
@@ -80,6 +83,18 @@ export class BalanceUsecaseService {
           return of(cosmosAccAddress);
         }
         return this.rest.getAllBalances$(cosmosAccAddress);
+      }),
+    );
+  }
+  get rewards$(): Observable<
+    CosmosDistributionV1beta1QueryDelegationTotalRewardsResponse | null | undefined
+  > {
+    return this.cosmosAccAddress$.pipe(
+      mergeMap((cosmosAccAddress) => {
+        if (!cosmosAccAddress) {
+          return of(cosmosAccAddress);
+        }
+        return this.rest.getDelegationTotalRewards$(cosmosAccAddress);
       }),
     );
   }

--- a/projects/portal/src/app/pages/dialogs/delegate/withdraw-all-delegator-reward-form-dialog/withdraw-all-delegator-reward-form-dialog.component.html
+++ b/projects/portal/src/app/pages/dialogs/delegate/withdraw-all-delegator-reward-form-dialog/withdraw-all-delegator-reward-form-dialog.component.html
@@ -1,0 +1,6 @@
+<view-withdraw-all-delegator-reward-form-dialog
+  [currentStoredWallet]="currentStoredWallet$ | async"
+  [minimumGasPrices]="minimumGasPrices$ | async"
+  [validator]="validator"
+  (appSubmit)="onSubmit($event)"
+></view-withdraw-all-delegator-reward-form-dialog>

--- a/projects/portal/src/app/pages/dialogs/delegate/withdraw-all-delegator-reward-form-dialog/withdraw-all-delegator-reward-form-dialog.component.html
+++ b/projects/portal/src/app/pages/dialogs/delegate/withdraw-all-delegator-reward-form-dialog/withdraw-all-delegator-reward-form-dialog.component.html
@@ -2,5 +2,7 @@
   [currentStoredWallet]="currentStoredWallet$ | async"
   [minimumGasPrices]="minimumGasPrices$ | async"
   [validator]="validator"
+  [delegations]="delegations$ | async"
+  [delegatedValidators]="delegatedValidators$ | async"
   (appSubmit)="onSubmit($event)"
 ></view-withdraw-all-delegator-reward-form-dialog>

--- a/projects/portal/src/app/pages/dialogs/delegate/withdraw-all-delegator-reward-form-dialog/withdraw-all-delegator-reward-form-dialog.component.ts
+++ b/projects/portal/src/app/pages/dialogs/delegate/withdraw-all-delegator-reward-form-dialog/withdraw-all-delegator-reward-form-dialog.component.ts
@@ -1,14 +1,18 @@
 import { Component, Inject, OnInit } from '@angular/core';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import cosmosclient from '@cosmos-client/core';
-import { InlineResponse20041Validators } from '@cosmos-client/core/esm/openapi/api';
+import {
+  InlineResponse20038DelegationResponses,
+  InlineResponse20041Validators,
+} from '@cosmos-client/core/esm/openapi/api';
 import { ConfigService } from 'projects/portal/src/app/models/config.service';
+import { CosmosRestService } from 'projects/portal/src/app/models/cosmos-rest.service';
 import { DistributionApplicationService } from 'projects/portal/src/app/models/cosmos/distribution.application.service';
 import { StoredWallet } from 'projects/portal/src/app/models/wallets/wallet.model';
 import { WalletService } from 'projects/portal/src/app/models/wallets/wallet.service';
-import { WithdrawDelegatorRewardOnSubmitEvent } from 'projects/portal/src/app/views/dialogs/delegate/withdraw-delegator-reward-form-dialog/withdraw-delegator-reward-form-dialog.component';
-import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { WithdrawAllDelegatorRewardOnSubmitEvent } from 'projects/portal/src/app/views/dialogs/delegate/withdraw-all-delegator-reward-form-dialog/withdraw-all-delegator-reward-form-dialog.component';
+import { combineLatest, Observable } from 'rxjs';
+import { filter, map, mergeMap } from 'rxjs/operators';
 
 @Component({
   selector: 'app-withdraw-all-delegator-reward-form-dialog',
@@ -19,6 +23,9 @@ export class WithdrawAllDelegatorRewardFormDialogComponent implements OnInit {
   currentStoredWallet$: Observable<StoredWallet | null | undefined>;
   minimumGasPrices$: Observable<cosmosclient.proto.cosmos.base.v1beta1.ICoin[] | undefined>;
   validator: InlineResponse20041Validators | undefined;
+  validatorsList$: Observable<InlineResponse20041Validators[] | undefined>;
+  delegatedValidators$: Observable<(InlineResponse20041Validators | undefined)[] | undefined>;
+  delegations$: Observable<InlineResponse20038DelegationResponses[] | undefined>;
 
   constructor(
     @Inject(MAT_DIALOG_DATA)
@@ -26,18 +33,39 @@ export class WithdrawAllDelegatorRewardFormDialogComponent implements OnInit {
     public matDialogRef: MatDialogRef<WithdrawAllDelegatorRewardFormDialogComponent>,
     private readonly walletService: WalletService,
     private readonly configS: ConfigService,
+    private cosmosRest: CosmosRestService,
     private readonly distributionAppService: DistributionApplicationService,
   ) {
     this.validator = data;
     this.currentStoredWallet$ = this.walletService.currentStoredWallet$;
+    const address$ = this.currentStoredWallet$.pipe(
+      filter((wallet): wallet is StoredWallet => wallet !== undefined && wallet !== null),
+      map((wallet) => cosmosclient.AccAddress.fromString(wallet.address)),
+    );
     this.minimumGasPrices$ = this.configS.config$.pipe(map((config) => config?.minimumGasPrices));
+    this.validatorsList$ = this.cosmosRest.getValidators$();
+    this.delegations$ = address$.pipe(
+      mergeMap((address) => this.cosmosRest.getDelegatorDelegations$(address)),
+      map((result) => result.delegation_responses),
+    );
+    this.delegatedValidators$ = combineLatest([this.validatorsList$, this.delegations$]).pipe(
+      map(([validators, delegations]) =>
+        delegations?.map((delegation) =>
+          validators?.find(
+            (validator) => validator.operator_address == delegation.delegation?.validator_address,
+          ),
+        ),
+      ),
+    );
+
+    this.delegations$.subscribe((r) => console.log(r));
   }
 
   ngOnInit(): void {}
 
-  async onSubmit($event: WithdrawDelegatorRewardOnSubmitEvent) {
-    const txHash = await this.distributionAppService.withdrawDelegatorReward(
-      this.validator?.operator_address!,
+  async onSubmit($event: WithdrawAllDelegatorRewardOnSubmitEvent) {
+    const txHash = await this.distributionAppService.withdrawAllDelegatorReward(
+      $event.validators,
       $event.minimumGasPrice,
       $event.gasRatio,
     );

--- a/projects/portal/src/app/pages/dialogs/delegate/withdraw-all-delegator-reward-form-dialog/withdraw-all-delegator-reward-form-dialog.component.ts
+++ b/projects/portal/src/app/pages/dialogs/delegate/withdraw-all-delegator-reward-form-dialog/withdraw-all-delegator-reward-form-dialog.component.ts
@@ -57,8 +57,6 @@ export class WithdrawAllDelegatorRewardFormDialogComponent implements OnInit {
         ),
       ),
     );
-
-    this.delegations$.subscribe((r) => console.log(r));
   }
 
   ngOnInit(): void {}

--- a/projects/portal/src/app/pages/dialogs/delegate/withdraw-all-delegator-reward-form-dialog/withdraw-all-delegator-reward-form-dialog.component.ts
+++ b/projects/portal/src/app/pages/dialogs/delegate/withdraw-all-delegator-reward-form-dialog/withdraw-all-delegator-reward-form-dialog.component.ts
@@ -1,0 +1,46 @@
+import { Component, Inject, OnInit } from '@angular/core';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import cosmosclient from '@cosmos-client/core';
+import { InlineResponse20041Validators } from '@cosmos-client/core/esm/openapi/api';
+import { ConfigService } from 'projects/portal/src/app/models/config.service';
+import { DistributionApplicationService } from 'projects/portal/src/app/models/cosmos/distribution.application.service';
+import { StoredWallet } from 'projects/portal/src/app/models/wallets/wallet.model';
+import { WalletService } from 'projects/portal/src/app/models/wallets/wallet.service';
+import { WithdrawDelegatorRewardOnSubmitEvent } from 'projects/portal/src/app/views/dialogs/delegate/withdraw-delegator-reward-form-dialog/withdraw-delegator-reward-form-dialog.component';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+@Component({
+  selector: 'app-withdraw-all-delegator-reward-form-dialog',
+  templateUrl: './withdraw-all-delegator-reward-form-dialog.component.html',
+  styleUrls: ['./withdraw-all-delegator-reward-form-dialog.component.css'],
+})
+export class WithdrawAllDelegatorRewardFormDialogComponent implements OnInit {
+  currentStoredWallet$: Observable<StoredWallet | null | undefined>;
+  minimumGasPrices$: Observable<cosmosclient.proto.cosmos.base.v1beta1.ICoin[] | undefined>;
+  validator: InlineResponse20041Validators | undefined;
+
+  constructor(
+    @Inject(MAT_DIALOG_DATA)
+    public readonly data: InlineResponse20041Validators,
+    public matDialogRef: MatDialogRef<WithdrawAllDelegatorRewardFormDialogComponent>,
+    private readonly walletService: WalletService,
+    private readonly configS: ConfigService,
+    private readonly distributionAppService: DistributionApplicationService,
+  ) {
+    this.validator = data;
+    this.currentStoredWallet$ = this.walletService.currentStoredWallet$;
+    this.minimumGasPrices$ = this.configS.config$.pipe(map((config) => config?.minimumGasPrices));
+  }
+
+  ngOnInit(): void {}
+
+  async onSubmit($event: WithdrawDelegatorRewardOnSubmitEvent) {
+    const txHash = await this.distributionAppService.withdrawDelegatorReward(
+      this.validator?.operator_address!,
+      $event.minimumGasPrice,
+      $event.gasRatio,
+    );
+    this.matDialogRef.close(txHash);
+  }
+}

--- a/projects/portal/src/app/pages/dialogs/delegate/withdraw-all-delegator-reward-form-dialog/withdraw-all-delegator-reward-form-dialog.module.ts
+++ b/projects/portal/src/app/pages/dialogs/delegate/withdraw-all-delegator-reward-form-dialog/withdraw-all-delegator-reward-form-dialog.module.ts
@@ -1,0 +1,10 @@
+import { WithdrawAllDelegatorRewardFormDialogComponent } from './withdraw-all-delegator-reward-form-dialog.component';
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { WithdrawAllDelegatorRewardFormDialogModule } from 'projects/portal/src/app/views/dialogs/delegate/withdraw-all-delegator-reward-form-dialog/withdraw-all-delegator-reward-form-dialog.module';
+
+@NgModule({
+  declarations: [WithdrawAllDelegatorRewardFormDialogComponent],
+  imports: [CommonModule, WithdrawAllDelegatorRewardFormDialogModule],
+})
+export class AppWithdrawAllDelegatorRewardFormDialogModule {}

--- a/projects/portal/src/app/views/balance/balance.component.html
+++ b/projects/portal/src/app/views/balance/balance.component.html
@@ -138,6 +138,10 @@
   </mat-list>
 </mat-card>
 
+<button class="w-full" mat-flat-button color="accent" [disabled]="rewards">
+  Claim All Rewards
+</button>
+
 <h2 class="mt-6 mb-0">Network</h2>
 
 <mat-card class="mb-4">

--- a/projects/portal/src/app/views/balance/balance.component.html
+++ b/projects/portal/src/app/views/balance/balance.component.html
@@ -138,7 +138,15 @@
   </mat-list>
 </mat-card>
 
-<button class="w-full" mat-flat-button color="accent" [disabled]="rewards">
+<button
+  *ngIf="rewards && rewards.total"
+  class="w-full"
+  mat-flat-button
+  color="accent"
+  [disabled]="!rewards.total.length"
+  type="button"
+  (click)="onClickWithdrawAllDelegatorRewardButton()"
+>
   Claim All Rewards
 </button>
 

--- a/projects/portal/src/app/views/balance/balance.component.html
+++ b/projects/portal/src/app/views/balance/balance.component.html
@@ -115,6 +115,29 @@
   </mat-list>
 </mat-card>
 
+<h2 class="mt-6 mb-0">Claimable Delegator Reward</h2>
+<mat-card class="mb-4">
+  <mat-list>
+    <mat-list-item *ngIf="rewards === null">
+      <mat-spinner></mat-spinner>
+    </mat-list-item>
+    <mat-list-item *ngIf="rewards === undefined || rewards?.total === undefined">
+      No Rewards!
+    </mat-list-item>
+    <mat-list-item *ngIf="rewards && rewards.total && rewards.total.length === 0">
+      No Rewards!
+    </mat-list-item>
+    <ng-container *ngIf="rewards && rewards.total && rewards.total.length > 0">
+      <mat-list-item *ngFor="let totalReward of rewards.total; last as last">
+        <span class="flex-auto"></span>
+        <span class="mr-2">{{ totalReward.amount | number: '1.0-0' }}</span>
+        <span>{{ totalReward.denom }}</span>
+        <mat-divider *ngIf="!last"></mat-divider>
+      </mat-list-item>
+    </ng-container>
+  </mat-list>
+</mat-card>
+
 <h2 class="mt-6 mb-0">Network</h2>
 
 <mat-card class="mb-4">

--- a/projects/portal/src/app/views/balance/balance.component.ts
+++ b/projects/portal/src/app/views/balance/balance.component.ts
@@ -3,7 +3,10 @@ import { Clipboard } from '@angular/cdk/clipboard';
 import { Component, Input, OnInit, OnChanges } from '@angular/core';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import cosmosclient from '@cosmos-client/core';
-import { InlineResponse20012 } from '@cosmos-client/core/esm/openapi';
+import {
+  CosmosDistributionV1beta1QueryDelegationTotalRewardsResponse,
+  InlineResponse20012,
+} from '@cosmos-client/core/esm/openapi';
 
 @Component({
   selector: 'view-balance',
@@ -18,14 +21,15 @@ export class ViewBalanceComponent implements OnInit, OnChanges {
   @Input() publicKey?: string | null;
   @Input() valAddress?: string | null;
   @Input() balances?: cosmosclient.proto.cosmos.base.v1beta1.ICoin[] | null;
+  @Input() rewards?: CosmosDistributionV1beta1QueryDelegationTotalRewardsResponse | null;
   @Input() faucets?:
     | {
-      hasFaucet: boolean;
-      faucetURL: string;
-      denom: string;
-      creditAmount: number;
-      maxCredit: number;
-    }[]
+        hasFaucet: boolean;
+        faucetURL: string;
+        denom: string;
+        creditAmount: number;
+        maxCredit: number;
+      }[]
     | null;
   @Input() nodeInfo?: InlineResponse20012 | null;
 
@@ -37,7 +41,7 @@ export class ViewBalanceComponent implements OnInit, OnChanges {
     this.tempNodeInfo = this.nodeInfo as any;
   }
 
-  ngOnInit(): void { }
+  ngOnInit(): void {}
 
   // Todo: This lifecycle methods is temporal fix.
   // default_node_info in type definition of InlineResponse20012 is actually node_info.

--- a/projects/portal/src/app/views/balance/balance.component.ts
+++ b/projects/portal/src/app/views/balance/balance.component.ts
@@ -1,6 +1,6 @@
 import { WalletType } from '../../models/wallets/wallet.model';
 import { Clipboard } from '@angular/cdk/clipboard';
-import { Component, Input, OnInit, OnChanges } from '@angular/core';
+import { Component, Input, OnInit, OnChanges, EventEmitter, Output } from '@angular/core';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import cosmosclient from '@cosmos-client/core';
 import {
@@ -32,6 +32,7 @@ export class ViewBalanceComponent implements OnInit, OnChanges {
       }[]
     | null;
   @Input() nodeInfo?: InlineResponse20012 | null;
+  @Output() appWithdrawAllDelegatorReward: EventEmitter<{}>;
 
   // Todo: This is temporal fix.
   tempNodeInfo: any;
@@ -39,6 +40,7 @@ export class ViewBalanceComponent implements OnInit, OnChanges {
   constructor(private readonly snackBar: MatSnackBar, private clipboard: Clipboard) {
     // Todo: This is temporal fix.
     this.tempNodeInfo = this.nodeInfo as any;
+    this.appWithdrawAllDelegatorReward = new EventEmitter();
   }
 
   ngOnInit(): void {}
@@ -61,5 +63,9 @@ export class ViewBalanceComponent implements OnInit, OnChanges {
       });
     }
     return false;
+  }
+
+  onClickWithdrawAllDelegatorRewardButton() {
+    this.appWithdrawAllDelegatorReward.emit();
   }
 }

--- a/projects/portal/src/app/views/cosmos/staking/validators/validator/validator.component.html
+++ b/projects/portal/src/app/views/cosmos/staking/validators/validator/validator.component.html
@@ -35,7 +35,7 @@
         </mat-list-item>
         <mat-divider [inset]="true"></mat-divider>
         <mat-list-item>
-          <span>Delegator Shares: </span>
+          <span>Claimable Delegator Reward: </span>
           <span class="flex-auto"></span>
           <span class="ml-2 break-all">
             <span>{{ validator?.delegator_shares | floor }}</span>

--- a/projects/portal/src/app/views/delegate/validators/validators.component.html
+++ b/projects/portal/src/app/views/delegate/validators/validators.component.html
@@ -1,3 +1,105 @@
+<h2 class="mb-0">Delegations</h2>
+<ng-container *ngIf="delegations === null; then loading; else loadedDelegations"> </ng-container>
+<ng-template #loadedDelegations>
+  <ng-container
+    *ngIf="(delegations?.length || 0) > 0; then existDelegations; else emptyDelegations"
+  >
+  </ng-container>
+</ng-template>
+<ng-template #existDelegations>
+  <mat-card class="mb-4">
+    <mat-list>
+      <mat-list-item>
+        <span class="w-6/12 truncate pl-8 pr-8">Validator</span>
+        <span class="w-3/12 truncate text-right pr-4">Amount</span>
+        <span class="w-3/12 truncate text-right pr-4">Shares</span>
+        <mat-divider></mat-divider>
+      </mat-list-item>
+    </mat-list>
+    <mat-nav-list>
+      <ng-container *ngFor="let delegation of delegations; last as last">
+        <ng-container *ngFor="let validator of delegatedValidators">
+          <mat-list-item
+            *ngIf="delegation.delegation?.validator_address === validator?.operator_address"
+            (click)="onClickValidator(validator!)"
+          >
+            <mat-icon
+              matListIcon
+              [ngStyle]="{ color: getColorCode(delegation.delegation?.validator_address ?? '') }"
+            >
+              circle
+            </mat-icon>
+            <span class="w-6/12 break-all text-sm sm:text-base"
+              >{{ validator?.description?.moniker }}
+            </span>
+            <span class="w-3/12 break-all text-sm sm:text-base text-right pl-4"
+              >{{ delegation.balance?.amount }} {{ delegation.balance?.denom }}
+            </span>
+            <span class="w-3/12 break-all text-sm sm:text-base text-right pl-4"
+              >{{ toNumber(delegation.delegation?.shares ?? '0') }}
+              {{ delegation.balance?.denom }}</span
+            >
+          </mat-list-item>
+        </ng-container>
+        <mat-divider *ngIf="!last" [inset]="true"></mat-divider>
+      </ng-container>
+    </mat-nav-list>
+  </mat-card>
+</ng-template>
+<ng-template #emptyDelegations>
+  <p>There is no delegations.</p>
+</ng-template>
+
+<ng-container
+  *ngIf="(unbondingDelegations?.length || 0) > 0; then existUnbonding; else emptyUnbonding"
+>
+</ng-container>
+<ng-template #existUnbonding>
+  <h2 class="mb-0">OnGoing Unbonding</h2>
+  <mat-card class="mb-4">
+    <mat-list>
+      <mat-list-item>
+        <span class="w-6/12 break-all truncate pl-8 pr-8">Validator</span>
+        <span class="w-4/12 break-all truncate text-center">Date</span>
+        <span class="w-2/12 break-all truncate text-right pl-2">Amount</span>
+        <mat-divider></mat-divider>
+      </mat-list-item>
+    </mat-list>
+    <mat-nav-list>
+      <ng-container *ngFor="let unbondingDelegation of unbondingDelegations; last as last">
+        <ng-container *ngFor="let validator of delegatedValidators">
+          <mat-list-item
+            *ngIf="unbondingDelegation?.unbond?.validator_address === validator?.operator_address"
+            (click)="onClickValidator(validator!)"
+          >
+            <mat-icon
+              matListIcon
+              [ngStyle]="{
+                color: getColorCode(unbondingDelegation?.unbond?.validator_address ?? '')
+              }"
+            >
+              circle
+            </mat-icon>
+            <span class="w-6/12 break-all text-sm sm:text-base"
+              >{{ validator?.description?.moniker }}
+            </span>
+            <span class="w-4/12 break-all text-sm sm:text-base text-right pr-2"
+              >{{
+              unbondingDelegation?.unbond?.entries?.[0]?.completion_time | date : 'yyyy-M-d a h:mm:ss z'}}
+            </span>
+            <span class="w-2/12 break-all text-sm sm:text-base text-right pr-2">{{
+              unbondingDelegation?.unbond?.entries?.[0]?.balance }}</span>
+          </mat-list-item>
+        </ng-container>
+        <mat-divider *ngIf="!last" [inset]="true"></mat-divider>
+      </ng-container>
+    </mat-nav-list>
+  </mat-card>
+</ng-template>
+<ng-template #emptyUnbonding>
+  <p>There is no unbonding delegations.</p>
+</ng-template>
+
 <div class="flex flex-row items-end mb-2">
   <h2 class="mb-0">Validators</h2>
   <span class="flex-auto"></span>
@@ -27,23 +129,29 @@
       </mat-list-item>
     </mat-list>
     <mat-nav-list>
-      <mat-list-item *ngFor="let validator of validators; last as last" (click)="onClickValidator(validator.val)">
-        <mat-icon matListIcon [ngStyle]="{ color: getColorCode(validator.val.operator_address ?? '') }">
+      <mat-list-item
+        *ngFor="let validator of validators; last as last"
+        (click)="onClickValidator(validator.val)"
+      >
+        <mat-icon
+          matListIcon
+          [ngStyle]="{ color: getColorCode(validator.val.operator_address ?? '') }"
+        >
           circle
         </mat-icon>
         <span class="w-1/2 break-all text-sm sm:text-base">{{
           validator.val.description?.moniker
-          }}</span>
+        }}</span>
         <span class="flex-auto"></span>
         <span class="w-2/12 text-right break-all text-sm sm:text-base">{{
           validator.share | percent: '1.2-2'
-          }}</span>
+        }}</span>
         <span class="w-2/12 text-right break-all text-sm sm:text-base">{{
           validator.val.tokens | unitConversion
-          }}</span>
+        }}</span>
         <span class="w-2/12 text-right break-all text-sm sm:text-base">{{
           validator.val.commission?.commission_rates?.rate | percent: '1.0-0'
-          }}</span>
+        }}</span>
         <mat-divider *ngIf="!last"></mat-divider>
       </mat-list-item>
     </mat-nav-list>
@@ -51,81 +159,4 @@
 </ng-template>
 <ng-template #empty>
   <p>There is no validators.</p>
-</ng-template>
-
-<h2 class="mb-0">Delegations</h2>
-<ng-container *ngIf="delegations === null; then loading; else loadedDelegations"> </ng-container>
-<ng-template #loadedDelegations>
-  <ng-container *ngIf="(delegations?.length || 0) > 0; then existDelegations; else emptyDelegations">
-  </ng-container>
-</ng-template>
-<ng-template #existDelegations>
-  <mat-card class="mb-4">
-    <mat-list>
-      <mat-list-item>
-        <span class="w-6/12 truncate pl-8 pr-8">Validator</span>
-        <span class="w-3/12 truncate text-right pr-4">Amount</span>
-        <span class="w-3/12 truncate text-right pr-4">Shares</span>
-        <mat-divider></mat-divider>
-      </mat-list-item>
-    </mat-list>
-    <mat-nav-list>
-      <ng-container *ngFor="let delegation of delegations; last as last">
-        <ng-container *ngFor="let validator of delegatedValidators">
-          <mat-list-item *ngIf="delegation.delegation?.validator_address == validator?.operator_address"
-            (click)="onClickValidator(validator!)">
-            <mat-icon matListIcon [ngStyle]="{ color: getColorCode(delegation.delegation?.validator_address ?? '') }">
-              circle
-            </mat-icon>
-            <span class="w-6/12 break-all text-sm sm:text-base">{{ validator?.description?.moniker }} </span>
-            <span class="w-3/12 break-all text-sm sm:text-base text-right pl-4">{{
-              delegation.balance?.amount }} {{ delegation.balance?.denom }} </span>
-            <span class="w-3/12 break-all text-sm sm:text-base text-right pl-4">{{
-              toNumber(delegation.delegation?.shares ?? '0') }} {{ delegation.balance?.denom }}</span>
-          </mat-list-item>
-        </ng-container>
-        <mat-divider *ngIf="!last" [inset]="true"></mat-divider>
-      </ng-container>
-    </mat-nav-list>
-  </mat-card>
-</ng-template>
-<ng-template #emptyDelegations>
-  <p>There is no delegations.</p>
-</ng-template>
-
-<ng-container *ngIf="(unbondingDelegations?.length || 0) > 0; then unbonding; else beforeUnbonding">
-</ng-container>
-<ng-template #unbonding>
-  <h2 class="mb-0">OnGoing Unbonding</h2>
-  <mat-card class="mb-4">
-    <mat-list>
-      <mat-list-item>
-        <span class="w-6/12 break-all truncate pl-8 pr-8">Validator</span>
-        <span class="w-4/12 break-all truncate text-center">Date</span>
-        <span class="w-2/12 break-all truncate text-right pl-2">Amount</span>
-        <mat-divider></mat-divider>
-      </mat-list-item>
-    </mat-list>
-    <mat-nav-list>
-      <ng-container *ngFor="let unbondingDelegation of unbondingDelegations; last as last">
-        <ng-container *ngFor="let validator of delegatedValidators">
-          <mat-list-item *ngIf="unbondingDelegation?.unbond?.validator_address == validator?.operator_address"
-            (click)="onClickValidator(validator!)">
-            <mat-icon matListIcon
-              [ngStyle]="{ color: getColorCode(unbondingDelegation?.unbond?.validator_address ?? '') }">
-              circle
-            </mat-icon>
-            <span class="w-6/12 break-all text-sm sm:text-base">{{ validator?.description?.moniker }} </span>
-            <span class="w-4/12 break-all text-sm sm:text-base text-right pr-2">{{
-              unbondingDelegation?.unbond?.entries?.[0]?.completion_time | date : 'yyyy-M-d a h:mm:ss z'}} </span>
-            <span class="w-2/12 break-all text-sm sm:text-base text-right pr-2">{{
-              unbondingDelegation?.unbond?.entries?.[0]?.balance }}</span>
-          </mat-list-item>
-        </ng-container>
-        <mat-divider *ngIf="!last" [inset]="true"></mat-divider>
-      </ng-container>
-    </mat-nav-list>
-  </mat-card>
-</ng-template>
-<ng-template #beforeUnbonding>
 </ng-template>

--- a/projects/portal/src/app/views/delegate/validators/validators.component.html
+++ b/projects/portal/src/app/views/delegate/validators/validators.component.html
@@ -12,7 +12,7 @@
       <mat-list-item>
         <span class="w-6/12 truncate pl-8 pr-8">Validator</span>
         <span class="w-3/12 truncate text-right pr-4">Amount</span>
-        <span class="w-3/12 truncate text-right pr-4">Shares</span>
+        <span class="w-3/12 truncate text-right pr-4">Rewards</span>
         <mat-divider></mat-divider>
       </mat-list-item>
     </mat-list>

--- a/projects/portal/src/app/views/dialogs/delegate/delegate-menu-dialog/delegate-menu-dialog.component.html
+++ b/projects/portal/src/app/views/dialogs/delegate/delegate-menu-dialog/delegate-menu-dialog.component.html
@@ -48,12 +48,19 @@
         <mat-list-item>
           <span class="column-name">Delegated Amount</span>
           <span class="flex-auto"></span>
-          <span class="column-value">{{ delegateAmount?.amount | number:'1.0-0' }} {{ delegateAmount?.denom }}</span>
+          <span class="column-value"
+            >{{ delegateAmount?.amount | number: '1.0-0' }} {{ delegateAmount?.denom }}</span
+          >
         </mat-list-item>
       </mat-list>
       <mat-list class="w-full">
         <ng-container
-          *ngIf="(totalRewards?.total?.length || 0) > 0; then existTotalRewards; else emptyTotalRewards"        >
+          *ngIf="
+            (totalRewards?.total?.length || 0) > 0;
+            then existTotalRewards;
+            else emptyTotalRewards
+          "
+        >
         </ng-container>
         <ng-template #emptyTotalRewards>
           <mat-list-item>
@@ -66,7 +73,7 @@
           <mat-list-item *ngFor="let eachTotalReward of totalRewards?.total; last as last">
             <span class="column-name">Claimable Delegator Reward</span>
             <span class="flex-auto"></span>
-            <span>{{ eachTotalReward.amount | number:'1.0-0' }} {{ eachTotalReward.denom }}</span>
+            <span>{{ eachTotalReward.amount | number: '1.0-0' }} {{ eachTotalReward.denom }}</span>
           </mat-list-item>
         </ng-template>
       </mat-list>
@@ -90,10 +97,12 @@
           </mat-list-item>
         </ng-template>
         <ng-template #existCommission>
-          <mat-list-item *ngFor="let commission of commission?.commission?.commission; last as last">
+          <mat-list-item
+            *ngFor="let commission of commission?.commission?.commission; last as last"
+          >
             <span class="column-name">Claimable Validator Commission</span>
             <span class="flex-auto"></span>
-            <span>{{ commission.amount | number:'1.0-0' }} {{ commission.denom }}</span>
+            <span>{{ commission.amount | number: '1.0-0' }} {{ commission.denom }}</span>
           </mat-list-item>
         </ng-template>
       </mat-list>
@@ -134,7 +143,7 @@
         class="inline-flex justify-between items-center w-full m-3 bg-white"
         (click)="onClickWithdrawDelegatorRewardButton()"
       >
-        <span class="text-black">Withdraw delegator reward</span>
+        <span class="text-black">Claim delegator reward</span>
       </button>
     </ng-container>
     <ng-container *ngIf="isValidator">
@@ -143,8 +152,8 @@
         class="inline-flex justify-between items-center w-full m-3 bg-white"
         (click)="onClickWithdrawValidatorCommissionButton()"
       >
-        <span class="text-black">Withdraw validator commission</span>
+        <span class="text-black">Claim validator commission</span>
       </button>
     </ng-container>
-</div>
+  </div>
 </mat-dialog-content>

--- a/projects/portal/src/app/views/dialogs/delegate/withdraw-all-delegator-reward-form-dialog/withdraw-all-delegator-reward-form-dialog.component.html
+++ b/projects/portal/src/app/views/dialogs/delegate/withdraw-all-delegator-reward-form-dialog/withdraw-all-delegator-reward-form-dialog.component.html
@@ -1,7 +1,7 @@
 <mat-dialog-content>
   <div class="flex flex-col items-center">
     <img class="m-6 w-12 h-12" src="assets/favicon.png" alt="UnUniFi logo" />
-    <div class="font-bold text-xl m-3">Claim all delegator reward</div>
+    <div class="font-bold text-xl m-3">Claim all delegator rewards</div>
   </div>
 
   <mat-list>
@@ -108,7 +108,7 @@
     </mat-accordion>
 
     <button mat-flat-button class="w-full mt-4" color="accent" [disabled]="formRef.invalid">
-      Claim Delegator Reward
+      Claim Delegator Rewards
     </button>
   </form>
 </mat-dialog-content>

--- a/projects/portal/src/app/views/dialogs/delegate/withdraw-all-delegator-reward-form-dialog/withdraw-all-delegator-reward-form-dialog.component.html
+++ b/projects/portal/src/app/views/dialogs/delegate/withdraw-all-delegator-reward-form-dialog/withdraw-all-delegator-reward-form-dialog.component.html
@@ -1,0 +1,101 @@
+<mat-dialog-content>
+  <div class="flex flex-col items-center">
+    <img class="m-6 w-12 h-12" src="assets/favicon.png" alt="UnUniFi logo" />
+    <div class="font-bold text-xl m-3">Claim all delegator reward</div>
+  </div>
+
+  <mat-list>
+    <mat-label>To. (Validator)</mat-label>
+    <mat-list-item>
+      <mat-icon matListIcon [ngStyle]="{ color: getColorCode(validator?.operator_address!) }"
+        >circle</mat-icon
+      >
+      <div mat-line>
+        <span>{{ validator?.description?.moniker }}</span>
+      </div>
+    </mat-list-item>
+  </mat-list>
+
+  <mat-list>
+    <mat-label>From. (Delegator)</mat-label>
+    <mat-list-item>
+      <mat-icon matListIcon [ngStyle]="{ color: getColorCode(currentStoredWallet?.address!) }"
+        >circle</mat-icon
+      >
+      <div mat-line>
+        <span>{{ currentStoredWallet?.id }}</span>
+      </div>
+    </mat-list-item>
+  </mat-list>
+
+  <form #formRef="ngForm" (submit)="onSubmit()">
+    <h3 class="pt-3">Gas Settings</h3>
+    <mat-form-field class="w-full">
+      <mat-label>Gas Ratio</mat-label>
+      <input [(ngModel)]="gasRatio" name="gas-ratio" matInput type="number" required />
+    </mat-form-field>
+    <mat-button-toggle-group class="flex mb-4" value="low">
+      <mat-button-toggle class="flex-auto" value="low" (click)="changeGasRatio(0)"
+        >Low</mat-button-toggle
+      >
+      <mat-button-toggle class="flex-auto" value="middle" (click)="changeGasRatio(1.1)"
+        >Middle</mat-button-toggle
+      >
+      <mat-button-toggle class="flex-auto" value="high" (click)="changeGasRatio(2)"
+        >High</mat-button-toggle
+      >
+    </mat-button-toggle-group>
+
+    <mat-accordion>
+      <mat-expansion-panel>
+        <mat-expansion-panel-header>
+          <mat-panel-title> Advanced </mat-panel-title>
+          <mat-panel-description> Change Default Gas Price </mat-panel-description>
+        </mat-expansion-panel-header>
+        <div class="flex flex-col content-content lg:flex-row">
+          <mat-form-field class="flex-auto">
+            <mat-label>Gas Denom</mat-label>
+            <mat-select
+              [(ngModel)]="selectedGasPrice && selectedGasPrice.denom"
+              name="minimum-gas-denom"
+              required
+              (valueChange)="onMinimumGasDenomChanged($event)"
+            >
+              <mat-option
+                *ngFor="let minimumGasPriceOption of minimumGasPrices"
+                [value]="minimumGasPriceOption.denom"
+              >
+                {{ minimumGasPriceOption.denom }}
+              </mat-option>
+            </mat-select>
+          </mat-form-field>
+          <mat-form-field class="flex-auto">
+            <mat-label>Gas Price</mat-label>
+            <input
+              [(ngModel)]="selectedGasPrice && selectedGasPrice.amount"
+              #minimumGasPriceRef
+              name="minimum-gas-price"
+              matInput
+              type="number"
+              [min]="0"
+              required
+            />
+          </mat-form-field>
+        </div>
+        <mat-slider
+          class="w-full"
+          [max]="1"
+          [min]="0"
+          [step]="0.015"
+          [(ngModel)]="selectedGasPrice && selectedGasPrice.amount"
+          name="minimum-gas-price-slider"
+        >
+        </mat-slider>
+      </mat-expansion-panel>
+    </mat-accordion>
+
+    <button mat-flat-button class="w-full mt-4" color="accent" [disabled]="formRef.invalid">
+      Claim Delegator Reward
+    </button>
+  </form>
+</mat-dialog-content>

--- a/projects/portal/src/app/views/dialogs/delegate/withdraw-all-delegator-reward-form-dialog/withdraw-all-delegator-reward-form-dialog.component.html
+++ b/projects/portal/src/app/views/dialogs/delegate/withdraw-all-delegator-reward-form-dialog/withdraw-all-delegator-reward-form-dialog.component.html
@@ -5,19 +5,32 @@
   </div>
 
   <mat-list>
-    <mat-label>To. (Validator)</mat-label>
-    <mat-list-item>
-      <mat-icon matListIcon [ngStyle]="{ color: getColorCode(validator?.operator_address!) }"
-        >circle</mat-icon
-      >
-      <div mat-line>
-        <span>{{ validator?.description?.moniker }}</span>
-      </div>
-    </mat-list-item>
+    <mat-label>Available Rewards</mat-label>
+    <ng-container *ngFor="let delegation of delegations; last as last">
+      <ng-container *ngFor="let validator of delegatedValidators">
+        <mat-list-item
+          *ngIf="delegation.delegation?.validator_address === validator?.operator_address"
+        >
+          <mat-icon
+            matListIcon
+            [ngStyle]="{ color: getColorCode(delegation.delegation?.validator_address ?? '') }"
+          >
+            circle
+          </mat-icon>
+          <span class="w-2/3 break-all text-sm sm:text-base"
+            >{{ validator?.description?.moniker }}
+          </span>
+          <span class="w-1/3 break-all text-sm sm:text-base text-right pl-4"
+            >{{ toNumber(delegation.delegation?.shares ?? '0') }}
+            {{ delegation.balance?.denom }}</span
+          >
+        </mat-list-item>
+      </ng-container>
+    </ng-container>
   </mat-list>
 
   <mat-list>
-    <mat-label>From. (Delegator)</mat-label>
+    <mat-label>Delegator</mat-label>
     <mat-list-item>
       <mat-icon matListIcon [ngStyle]="{ color: getColorCode(currentStoredWallet?.address!) }"
         >circle</mat-icon

--- a/projects/portal/src/app/views/dialogs/delegate/withdraw-all-delegator-reward-form-dialog/withdraw-all-delegator-reward-form-dialog.component.ts
+++ b/projects/portal/src/app/views/dialogs/delegate/withdraw-all-delegator-reward-form-dialog/withdraw-all-delegator-reward-form-dialog.component.ts
@@ -1,10 +1,14 @@
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import cosmosclient from '@cosmos-client/core';
-import { InlineResponse20041Validators } from '@cosmos-client/core/esm/openapi';
+import {
+  InlineResponse20038DelegationResponses,
+  InlineResponse20041Validators,
+} from '@cosmos-client/core/esm/openapi';
 import * as crypto from 'crypto';
 import { StoredWallet } from 'projects/portal/src/app/models/wallets/wallet.model';
 
-export type WithdrawDelegatorRewardOnSubmitEvent = {
+export type WithdrawAllDelegatorRewardOnSubmitEvent = {
+  validators: string[];
   minimumGasPrice: cosmosclient.proto.cosmos.base.v1beta1.ICoin;
   gasRatio: number;
 };
@@ -21,9 +25,13 @@ export class WithdrawAllDelegatorRewardFormDialogComponent implements OnInit {
   minimumGasPrices?: cosmosclient.proto.cosmos.base.v1beta1.ICoin[] | null;
   @Input()
   validator?: InlineResponse20041Validators | null;
+  @Input()
+  delegations?: InlineResponse20038DelegationResponses[] | null;
+  @Input()
+  delegatedValidators?: (InlineResponse20041Validators | undefined)[] | null;
 
   @Output()
-  appSubmit: EventEmitter<WithdrawDelegatorRewardOnSubmitEvent>;
+  appSubmit: EventEmitter<WithdrawAllDelegatorRewardOnSubmitEvent>;
 
   selectedGasPrice?: cosmosclient.proto.cosmos.base.v1beta1.ICoin;
   availableDenoms?: string[];
@@ -41,7 +49,7 @@ export class WithdrawAllDelegatorRewardFormDialogComponent implements OnInit {
     }
   }
 
-  ngOnInit(): void { }
+  ngOnInit(): void {}
 
   getColorCode(address: string) {
     const hash = crypto
@@ -56,11 +64,22 @@ export class WithdrawAllDelegatorRewardFormDialogComponent implements OnInit {
     this.gasRatio = ratio;
   }
 
+  toNumber(str: string) {
+    return Number(str);
+  }
+
   onSubmit() {
     if (this.selectedGasPrice === undefined) {
       return;
     }
+    if (!this.delegatedValidators) {
+      return;
+    }
+    const validatorAddresses = this.delegatedValidators
+      .map((validator) => validator?.operator_address)
+      .filter((validator): validator is string => typeof validator == 'string');
     this.appSubmit.emit({
+      validators: validatorAddresses,
       minimumGasPrice: this.selectedGasPrice,
       gasRatio: this.gasRatio,
     });

--- a/projects/portal/src/app/views/dialogs/delegate/withdraw-all-delegator-reward-form-dialog/withdraw-all-delegator-reward-form-dialog.component.ts
+++ b/projects/portal/src/app/views/dialogs/delegate/withdraw-all-delegator-reward-form-dialog/withdraw-all-delegator-reward-form-dialog.component.ts
@@ -1,0 +1,80 @@
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import cosmosclient from '@cosmos-client/core';
+import { InlineResponse20041Validators } from '@cosmos-client/core/esm/openapi';
+import * as crypto from 'crypto';
+import { StoredWallet } from 'projects/portal/src/app/models/wallets/wallet.model';
+
+export type WithdrawDelegatorRewardOnSubmitEvent = {
+  minimumGasPrice: cosmosclient.proto.cosmos.base.v1beta1.ICoin;
+  gasRatio: number;
+};
+
+@Component({
+  selector: 'view-withdraw-all-delegator-reward-form-dialog',
+  templateUrl: './withdraw-all-delegator-reward-form-dialog.component.html',
+  styleUrls: ['./withdraw-all-delegator-reward-form-dialog.component.css'],
+})
+export class WithdrawAllDelegatorRewardFormDialogComponent implements OnInit {
+  @Input()
+  currentStoredWallet?: StoredWallet | null;
+  @Input()
+  minimumGasPrices?: cosmosclient.proto.cosmos.base.v1beta1.ICoin[] | null;
+  @Input()
+  validator?: InlineResponse20041Validators | null;
+
+  @Output()
+  appSubmit: EventEmitter<WithdrawDelegatorRewardOnSubmitEvent>;
+
+  selectedGasPrice?: cosmosclient.proto.cosmos.base.v1beta1.ICoin;
+  availableDenoms?: string[];
+  gasRatio: number;
+
+  constructor() {
+    this.appSubmit = new EventEmitter();
+    this.availableDenoms = ['uguu'];
+    this.gasRatio = 0;
+  }
+
+  ngOnChanges(): void {
+    if (this.minimumGasPrices && this.minimumGasPrices.length > 0) {
+      this.selectedGasPrice = this.minimumGasPrices[0];
+    }
+  }
+
+  ngOnInit(): void { }
+
+  getColorCode(address: string) {
+    const hash = crypto
+      .createHash('sha256')
+      .update(Buffer.from(address ?? ''))
+      .digest()
+      .toString('hex');
+    return `#${hash.substr(0, 6)}`;
+  }
+
+  changeGasRatio(ratio: number) {
+    this.gasRatio = ratio;
+  }
+
+  onSubmit() {
+    if (this.selectedGasPrice === undefined) {
+      return;
+    }
+    this.appSubmit.emit({
+      minimumGasPrice: this.selectedGasPrice,
+      gasRatio: this.gasRatio,
+    });
+  }
+
+  onMinimumGasDenomChanged(denom: string): void {
+    this.selectedGasPrice = this.minimumGasPrices?.find(
+      (minimumGasPrice) => minimumGasPrice.denom === denom,
+    );
+  }
+
+  onMinimumGasAmountSliderChanged(amount: string): void {
+    if (this.selectedGasPrice) {
+      this.selectedGasPrice.amount = amount;
+    }
+  }
+}

--- a/projects/portal/src/app/views/dialogs/delegate/withdraw-all-delegator-reward-form-dialog/withdraw-all-delegator-reward-form-dialog.module.ts
+++ b/projects/portal/src/app/views/dialogs/delegate/withdraw-all-delegator-reward-form-dialog/withdraw-all-delegator-reward-form-dialog.module.ts
@@ -1,0 +1,12 @@
+import { MaterialModule } from '../../../material.module';
+import { WithdrawAllDelegatorRewardFormDialogComponent } from './withdraw-all-delegator-reward-form-dialog.component';
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+
+@NgModule({
+  declarations: [WithdrawAllDelegatorRewardFormDialogComponent],
+  imports: [CommonModule, FormsModule, MaterialModule],
+  exports: [WithdrawAllDelegatorRewardFormDialogComponent],
+})
+export class WithdrawAllDelegatorRewardFormDialogModule {}

--- a/projects/portal/src/app/views/dialogs/delegate/withdraw-delegator-reward-form-dialog/withdraw-delegator-reward-form-dialog.component.html
+++ b/projects/portal/src/app/views/dialogs/delegate/withdraw-delegator-reward-form-dialog/withdraw-delegator-reward-form-dialog.component.html
@@ -1,7 +1,7 @@
 <mat-dialog-content>
   <div class="flex flex-col items-center">
     <img class="m-6 w-12 h-12" src="assets/favicon.png" alt="UnUniFi logo" />
-    <div class="font-bold text-xl m-3">Withdraw delegator reward</div>
+    <div class="font-bold text-xl m-3">Claim delegator reward</div>
   </div>
 
   <mat-list>
@@ -95,7 +95,7 @@
     </mat-accordion>
 
     <button mat-flat-button class="w-full mt-4" color="accent" [disabled]="formRef.invalid">
-      Withdraw Delegator Reward
+      Claim Delegator Reward
     </button>
   </form>
 </mat-dialog-content>

--- a/projects/portal/src/app/views/dialogs/delegate/withdraw-validator-commission-form-dialog/withdraw-validator-commission-form-dialog.component.html
+++ b/projects/portal/src/app/views/dialogs/delegate/withdraw-validator-commission-form-dialog/withdraw-validator-commission-form-dialog.component.html
@@ -1,7 +1,7 @@
 <mat-dialog-content>
   <div class="flex flex-col items-center">
     <img class="m-6 w-12 h-12" src="assets/favicon.png" alt="UnUniFi logo" />
-    <div class="font-bold text-xl m-3">Withdraw Validator Commission</div>
+    <div class="font-bold text-xl m-3">Claim Validator Commission</div>
   </div>
 
   <mat-list>
@@ -83,7 +83,7 @@
     </mat-accordion>
 
     <button mat-flat-button class="w-full mt-4" color="accent" [disabled]="formRef.invalid">
-      Withdraw Delegator Reward
+      Claim Delegator Reward
     </button>
   </form>
 </mat-dialog-content>


### PR DESCRIPTION
close #231 

This PR update #232.

## Changes
### Layout of Delegate page
- `Delegates` above `Validators`

### View Text
- Shares => Rewards (ex. Claimable Delegator Reward)
- Withdraw => Claim

ex 
![スクリーンショット 2022-09-11 212958](https://user-images.githubusercontent.com/29295263/189527660-7a595f51-7607-4135-940c-09b6b241b259.png)

### Total Rewards on Balance page(Top page)
=> Next comment
- Add `Claimable Delegator Reward` on Balance page
- Add `Claim All Rewards` button
