### PR TITLE
refactor: [marketplace app]Abolish MatDialog and use Dialog of Angular CDK

### DIFF
--- a/projects/marketplace/src/app/app.module.ts
+++ b/projects/marketplace/src/app/app.module.ts
@@ -5,7 +5,6 @@ import { ToolbarModule } from './views/toolbar/toolbar.module';
 import { ViewModule } from './views/view.module';
 import { HttpClientModule } from '@angular/common/http';
 import { NgModule } from '@angular/core';
-import { MatDialogModule } from '@angular/material/dialog';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
@@ -31,7 +30,6 @@ import { LibWidgetNftMenuDialogModule } from 'projects/shared/src/lib/widgets/di
     AppRoutingModule,
     BrowserAnimationsModule,
     LoadingDialogModule,
-    MatDialogModule,
     MatSnackBarModule,
     ViewModule,
     ToolbarModule,

--- a/projects/marketplace/src/app/views/material.module.ts
+++ b/projects/marketplace/src/app/views/material.module.ts
@@ -6,7 +6,6 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import { MatCardModule } from '@angular/material/card';
 import { MatCheckboxModule } from '@angular/material/checkbox';
-import { MatDialogModule } from '@angular/material/dialog';
 import { MatDividerModule } from '@angular/material/divider';
 import { MatExpansionModule } from '@angular/material/expansion';
 import { MatFormFieldModule } from '@angular/material/form-field';
@@ -31,7 +30,6 @@ import { MatToolbarModule } from '@angular/material/toolbar';
     MatButtonModule,
     MatCardModule,
     MatCheckboxModule,
-    MatDialogModule,
     MatDividerModule,
     MatFormFieldModule,
     MatIconModule,

--- a/projects/marketplace/src/styles.css
+++ b/projects/marketplace/src/styles.css
@@ -33,6 +33,12 @@ mat-progress-spinner {
 mat-dialog-container {
   background: #3734B0 !important;
 }
+cdk-dialog-container {
+  display: block;
+  background: #3734B0 !important;
+  border-radius: 4px;
+  padding: 24px;
+}
 
 /* Todo: Current color system is very bad... */
 .mat-step {

--- a/projects/shared/src/lib/models/ununifi/tx/nft/nft-tx.application.service.ts
+++ b/projects/shared/src/lib/models/ununifi/tx/nft/nft-tx.application.service.ts
@@ -10,6 +10,7 @@ import { WalletService } from '../../../wallets/wallet.service';
 import { Nft } from '../../query/nft/nft.model';
 import { NftTxInfrastructureService } from './nft-tx.infrastructure.service';
 import { MsgListNftData } from './nft-tx.model';
+import { Dialog } from '@angular/cdk/dialog';
 import { Injectable } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
@@ -26,16 +27,14 @@ export class NftTxApplicationService {
     private readonly router: Router,
     private readonly snackBar: MatSnackBar,
     private readonly dialog: MatDialog,
+    private readonly tmp_dialog: Dialog,
     private readonly loadingDialog: LoadingDialogService,
     private readonly staking: NftTxInfrastructureService,
     private readonly walletService: WalletService,
   ) {}
 
   async openNftMenuDialog(nft: Nft): Promise<void> {
-    await this.dialog
-      .open(LibWidgetNftMenuDialogComponent, { data: nft })
-      .afterClosed()
-      .toPromise();
+    await this.tmp_dialog.open(LibWidgetNftMenuDialogComponent, { data: nft }).closed.toPromise();
   }
 
   async openListNftFormDialog(nft: Nft): Promise<void> {

--- a/projects/shared/src/lib/models/ununifi/tx/nft/nft-tx.application.service.ts
+++ b/projects/shared/src/lib/models/ununifi/tx/nft/nft-tx.application.service.ts
@@ -89,14 +89,16 @@ export class NftTxApplicationService {
     // // confirm fee only ununifi wallet type case
     // if (currentCosmosWallet.type === WalletType.ununifi) {
     //   const txFeeConfirmedResult = await this.dialog
-    //     .open(TxFeeConfirmDialogComponent, {
+    //     .open<{
+    //       fee: cosmosclient.proto.cosmos.base.v1beta1.ICoin;
+    //       isConfirmed: boolean;
+    //     }>(TxFeeConfirmDialogComponent, {
     //       data: {
     //         fee,
     //         isConfirmed: false,
     //       },
     //     })
-    //     .afterClosed()
-    //     .toPromise();
+    //     .closed.toPromise();
     //   if (txFeeConfirmedResult === undefined || txFeeConfirmedResult.isConfirmed === false) {
     //     this.snackBar.open('Tx was canceled', undefined, { duration: 6000 });
     //     return;

--- a/projects/shared/src/lib/models/ununifi/tx/nft/nft-tx.application.service.ts
+++ b/projects/shared/src/lib/models/ununifi/tx/nft/nft-tx.application.service.ts
@@ -12,7 +12,6 @@ import { NftTxInfrastructureService } from './nft-tx.infrastructure.service';
 import { MsgListNftData } from './nft-tx.model';
 import { Dialog } from '@angular/cdk/dialog';
 import { Injectable } from '@angular/core';
-import { MatDialog } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { Router } from '@angular/router';
 import cosmosclient from '@cosmos-client/core';
@@ -26,19 +25,18 @@ export class NftTxApplicationService {
   constructor(
     private readonly router: Router,
     private readonly snackBar: MatSnackBar,
-    private readonly dialog: MatDialog,
-    private readonly tmp_dialog: Dialog,
+    private readonly dialog: Dialog,
     private readonly loadingDialog: LoadingDialogService,
     private readonly staking: NftTxInfrastructureService,
     private readonly walletService: WalletService,
   ) {}
 
   async openNftMenuDialog(nft: Nft): Promise<void> {
-    await this.tmp_dialog.open(LibWidgetNftMenuDialogComponent, { data: nft }).closed.toPromise();
+    await this.dialog.open(LibWidgetNftMenuDialogComponent, { data: nft }).closed.toPromise();
   }
 
   async openListNftFormDialog(nft: Nft): Promise<void> {
-    const txHash = await this.tmp_dialog
+    const txHash = await this.dialog
       .open<string>(LibWidgetListNftFormDialogComponent, { data: nft })
       .closed.toPromise();
     await this.router.navigate(['txs', txHash]);

--- a/projects/shared/src/lib/models/ununifi/tx/nft/nft-tx.application.service.ts
+++ b/projects/shared/src/lib/models/ununifi/tx/nft/nft-tx.application.service.ts
@@ -38,10 +38,9 @@ export class NftTxApplicationService {
   }
 
   async openListNftFormDialog(nft: Nft): Promise<void> {
-    const txHash = await this.dialog
-      .open(LibWidgetListNftFormDialogComponent, { data: nft })
-      .afterClosed()
-      .toPromise();
+    const txHash = await this.tmp_dialog
+      .open<string>(LibWidgetListNftFormDialogComponent, { data: nft })
+      .closed.toPromise();
     await this.router.navigate(['txs', txHash]);
   }
 

--- a/projects/shared/src/lib/models/wallets/ununifi-wallet/ununifi-wallet.infrastructure.service.ts
+++ b/projects/shared/src/lib/models/wallets/ununifi-wallet/ununifi-wallet.infrastructure.service.ts
@@ -203,15 +203,23 @@ export class UnunifiWalletInfrastructureService implements IUnunifiWalletInfrast
     | (StoredWallet & { mnemonic: string; privateKey: string; checked: boolean; saved: boolean })
     | undefined
   > {
-    const backupResult: StoredWallet & {
-      mnemonic: string;
-      privateKey: string;
-      checked: boolean;
-      saved: boolean;
-    } = await this.dialog
-      .open(UnunifiBackupPrivateKeyWizardDialogComponent, { data: privateWallet })
-      .afterClosed()
-      .toPromise();
+    const backupResult:
+      | (StoredWallet & {
+          mnemonic: string;
+          privateKey: string;
+          checked: boolean;
+          saved: boolean;
+        })
+      | undefined = await this.tmp_dialog
+      .open<
+        StoredWallet & {
+          mnemonic: string;
+          privateKey: string;
+          checked: boolean;
+          saved: boolean;
+        }
+      >(UnunifiBackupPrivateKeyWizardDialogComponent, { data: privateWallet })
+      .closed.toPromise();
     return backupResult;
   }
 

--- a/projects/shared/src/lib/models/wallets/ununifi-wallet/ununifi-wallet.infrastructure.service.ts
+++ b/projects/shared/src/lib/models/wallets/ununifi-wallet/ununifi-wallet.infrastructure.service.ts
@@ -150,10 +150,12 @@ export class UnunifiWalletInfrastructureService implements IUnunifiWalletInfrast
   private async openUnunifiImportWalletWithPrivateKeyDialog(): Promise<
     (StoredWallet & { mnemonic: string; privateKey: string }) | undefined
   > {
-    const privateWallet: StoredWallet & { mnemonic: string; privateKey: string } = await this.dialog
-      .open(UnunifiImportWalletWithPrivateKeyFormDialogComponent)
-      .afterClosed()
-      .toPromise();
+    const privateWallet: (StoredWallet & { mnemonic: string; privateKey: string }) | undefined =
+      await this.tmp_dialog
+        .open<StoredWallet & { mnemonic: string; privateKey: string }>(
+          UnunifiImportWalletWithPrivateKeyFormDialogComponent,
+        )
+        .closed.toPromise();
     return privateWallet;
   }
 

--- a/projects/shared/src/lib/models/wallets/ununifi-wallet/ununifi-wallet.infrastructure.service.ts
+++ b/projects/shared/src/lib/models/wallets/ununifi-wallet/ununifi-wallet.infrastructure.service.ts
@@ -138,10 +138,12 @@ export class UnunifiWalletInfrastructureService implements IUnunifiWalletInfrast
   private async openUnunifiCreateWalletDialog(): Promise<
     (StoredWallet & { mnemonic: string; privateKey: string }) | undefined
   > {
-    const privateWallet: StoredWallet & { mnemonic: string; privateKey: string } = await this.dialog
-      .open(UnunifiCreateWalletFormDialogComponent)
-      .afterClosed()
-      .toPromise();
+    const privateWallet: (StoredWallet & { mnemonic: string; privateKey: string }) | undefined =
+      await this.tmp_dialog
+        .open<StoredWallet & { mnemonic: string; privateKey: string }>(
+          UnunifiCreateWalletFormDialogComponent,
+        )
+        .closed.toPromise();
     return privateWallet;
   }
 

--- a/projects/shared/src/lib/models/wallets/ununifi-wallet/ununifi-wallet.infrastructure.service.ts
+++ b/projects/shared/src/lib/models/wallets/ununifi-wallet/ununifi-wallet.infrastructure.service.ts
@@ -129,10 +129,9 @@ export class UnunifiWalletInfrastructureService implements IUnunifiWalletInfrast
   }
 
   private async openUnunifiSelectWalletDialog(): Promise<StoredWallet | undefined> {
-    const selectedStoredWallet: StoredWallet | undefined = await this.dialog
-      .open(UnunifiSelectWalletDialogComponent)
-      .afterClosed()
-      .toPromise();
+    const selectedStoredWallet: StoredWallet | undefined = await this.tmp_dialog
+      .open<StoredWallet>(UnunifiSelectWalletDialogComponent)
+      .closed.toPromise();
     return selectedStoredWallet;
   }
 

--- a/projects/shared/src/lib/models/wallets/ununifi-wallet/ununifi-wallet.infrastructure.service.ts
+++ b/projects/shared/src/lib/models/wallets/ununifi-wallet/ununifi-wallet.infrastructure.service.ts
@@ -14,6 +14,7 @@ import { KeyType } from '../../keys/key.model';
 import { StoredWallet } from '../wallet.model';
 import { WalletService } from '../wallet.service';
 import { IUnunifiWalletInfrastructureService } from './ununifi-wallet.service';
+import { Dialog } from '@angular/cdk/dialog';
 import { Injectable } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
@@ -26,6 +27,7 @@ export class UnunifiWalletInfrastructureService implements IUnunifiWalletInfrast
   constructor(
     private readonly walletService: WalletService,
     private readonly dialog: MatDialog,
+    private readonly tmp_dialog: Dialog,
     private snackBar: MatSnackBar,
     private loadingDialog: LoadingDialogService,
   ) {}
@@ -199,10 +201,9 @@ export class UnunifiWalletInfrastructureService implements IUnunifiWalletInfrast
   private async openConnectWalletCompletedDialog(
     connectedStoredWallet: StoredWallet,
   ): Promise<void> {
-    await this.dialog
+    await this.tmp_dialog
       .open(ConnectWalletCompletedDialogComponent, { data: connectedStoredWallet })
-      .afterClosed()
-      .toPromise();
+      .closed.toPromise();
   }
 
   private async openUnunifiKeyFormDialog(): Promise<StoredWallet & { privateKey: string }> {

--- a/projects/shared/src/lib/models/wallets/ununifi-wallet/ununifi-wallet.infrastructure.service.ts
+++ b/projects/shared/src/lib/models/wallets/ununifi-wallet/ununifi-wallet.infrastructure.service.ts
@@ -8,7 +8,10 @@ import { UnunifiCreateWalletFormDialogComponent } from '../../../views/dialogs/w
 import { UnunifiImportWalletWithMnemonicFormDialogComponent } from '../../../views/dialogs/wallets/ununifi/ununifi-import-wallet-with-mnemonic-form-dialog/ununifi-import-wallet-with-mnemonic-form-dialog.component';
 import { UnunifiImportWalletWithPrivateKeyFormDialogComponent } from '../../../views/dialogs/wallets/ununifi/ununifi-import-wallet-with-private-key-form-dialog/ununifi-import-wallet-with-private-key-form-dialog.component';
 import { UnunifiKeyFormDialogComponent } from '../../../views/dialogs/wallets/ununifi/ununifi-key-form-dialog/ununifi-key-form-dialog.component';
-import { UnunifiSelectCreateImportDialogComponent } from '../../../views/dialogs/wallets/ununifi/ununifi-select-create-import-dialog/ununifi-select-create-import-dialog.component';
+import {
+  UnunifiSelectCreateImportDialogData,
+  UnunifiSelectCreateImportDialogComponent,
+} from '../../../views/dialogs/wallets/ununifi/ununifi-select-create-import-dialog/ununifi-select-create-import-dialog.component';
 import { UnunifiSelectWalletDialogComponent } from '../../../views/dialogs/wallets/ununifi/ununifi-select-wallet-dialog/ununifi-select-wallet-dialog.component';
 import { KeyType } from '../../keys/key.model';
 import { StoredWallet } from '../wallet.model';
@@ -116,10 +119,11 @@ export class UnunifiWalletInfrastructureService implements IUnunifiWalletInfrast
   }
 
   private async openUnunifiSelectCreateImportDialog(): Promise<
-    'select' | 'import' | 'importWithPrivateKey' | 'create' | undefined
+    UnunifiSelectCreateImportDialogData | undefined
   > {
-    const selectedResult: 'select' | 'import' | 'importWithPrivateKey' | 'create' | undefined =
-      await this.dialog.open(UnunifiSelectCreateImportDialogComponent).afterClosed().toPromise();
+    const selectedResult: UnunifiSelectCreateImportDialogData | undefined = await this.tmp_dialog
+      .open<UnunifiSelectCreateImportDialogData>(UnunifiSelectCreateImportDialogComponent)
+      .closed.toPromise();
 
     return selectedResult;
   }

--- a/projects/shared/src/lib/models/wallets/ununifi-wallet/ununifi-wallet.infrastructure.service.ts
+++ b/projects/shared/src/lib/models/wallets/ununifi-wallet/ununifi-wallet.infrastructure.service.ts
@@ -231,11 +231,12 @@ export class UnunifiWalletInfrastructureService implements IUnunifiWalletInfrast
       .closed.toPromise();
   }
 
-  private async openUnunifiKeyFormDialog(): Promise<StoredWallet & { privateKey: string }> {
-    const privateKey = await this.dialog
-      .open(UnunifiKeyFormDialogComponent)
-      .afterClosed()
-      .toPromise();
+  private async openUnunifiKeyFormDialog(): Promise<
+    (StoredWallet & { privateKey: string }) | undefined
+  > {
+    const privateKey: (StoredWallet & { privateKey: string }) | undefined = await this.tmp_dialog
+      .open<StoredWallet & { privateKey: string }>(UnunifiKeyFormDialogComponent)
+      .closed.toPromise();
     return privateKey;
   }
 
@@ -274,7 +275,7 @@ export class UnunifiWalletInfrastructureService implements IUnunifiWalletInfrast
     txBuilder: cosmosclient.TxBuilder,
     signerBaseAccount: cosmosclient.proto.cosmos.auth.v1beta1.BaseAccount,
   ): Promise<cosmosclient.TxBuilder> {
-    const privateWallet: StoredWallet & { privateKey: string } =
+    const privateWallet: (StoredWallet & { privateKey: string }) | undefined =
       await this.openUnunifiKeyFormDialog();
     if (!privateWallet || !privateWallet.privateKey) {
       const errorMessage = 'Failed to get Wallet info from dialog! Tray again!';

--- a/projects/shared/src/lib/models/wallets/ununifi-wallet/ununifi-wallet.infrastructure.service.ts
+++ b/projects/shared/src/lib/models/wallets/ununifi-wallet/ununifi-wallet.infrastructure.service.ts
@@ -162,10 +162,12 @@ export class UnunifiWalletInfrastructureService implements IUnunifiWalletInfrast
   private async openUnunifiImportWalletWithMnemonicDialog(): Promise<
     (StoredWallet & { mnemonic: string; privateKey: string }) | undefined
   > {
-    const privateWallet: StoredWallet & { mnemonic: string; privateKey: string } = await this.dialog
-      .open(UnunifiImportWalletWithMnemonicFormDialogComponent)
-      .afterClosed()
-      .toPromise();
+    const privateWallet: (StoredWallet & { mnemonic: string; privateKey: string }) | undefined =
+      await this.tmp_dialog
+        .open<StoredWallet & { mnemonic: string; privateKey: string }>(
+          UnunifiImportWalletWithMnemonicFormDialogComponent,
+        )
+        .closed.toPromise();
     return privateWallet;
   }
 

--- a/projects/shared/src/lib/models/wallets/ununifi-wallet/ununifi-wallet.infrastructure.service.ts
+++ b/projects/shared/src/lib/models/wallets/ununifi-wallet/ununifi-wallet.infrastructure.service.ts
@@ -177,15 +177,23 @@ export class UnunifiWalletInfrastructureService implements IUnunifiWalletInfrast
     | (StoredWallet & { mnemonic: string; privateKey: string; checked: boolean; saved: boolean })
     | undefined
   > {
-    const backupResult: StoredWallet & {
-      mnemonic: string;
-      privateKey: string;
-      checked: boolean;
-      saved: boolean;
-    } = await this.dialog
-      .open(UnunifiBackupMnemonicAndPrivateKeyWizardDialogComponent, { data: privateWallet })
-      .afterClosed()
-      .toPromise();
+    const backupResult:
+      | (StoredWallet & {
+          mnemonic: string;
+          privateKey: string;
+          checked: boolean;
+          saved: boolean;
+        })
+      | undefined = await this.tmp_dialog
+      .open<
+        StoredWallet & {
+          mnemonic: string;
+          privateKey: string;
+          checked: boolean;
+          saved: boolean;
+        }
+      >(UnunifiBackupMnemonicAndPrivateKeyWizardDialogComponent, { data: privateWallet })
+      .closed.toPromise();
     return backupResult;
   }
 

--- a/projects/shared/src/lib/models/wallets/ununifi-wallet/ununifi-wallet.infrastructure.service.ts
+++ b/projects/shared/src/lib/models/wallets/ununifi-wallet/ununifi-wallet.infrastructure.service.ts
@@ -19,7 +19,6 @@ import { WalletService } from '../wallet.service';
 import { IUnunifiWalletInfrastructureService } from './ununifi-wallet.service';
 import { Dialog } from '@angular/cdk/dialog';
 import { Injectable } from '@angular/core';
-import { MatDialog } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import cosmosclient from '@cosmos-client/core';
 
@@ -29,8 +28,7 @@ import cosmosclient from '@cosmos-client/core';
 export class UnunifiWalletInfrastructureService implements IUnunifiWalletInfrastructureService {
   constructor(
     private readonly walletService: WalletService,
-    private readonly dialog: MatDialog,
-    private readonly tmp_dialog: Dialog,
+    private readonly dialog: Dialog,
     private snackBar: MatSnackBar,
     private loadingDialog: LoadingDialogService,
   ) {}
@@ -121,7 +119,7 @@ export class UnunifiWalletInfrastructureService implements IUnunifiWalletInfrast
   private async openUnunifiSelectCreateImportDialog(): Promise<
     UnunifiSelectCreateImportDialogData | undefined
   > {
-    const selectedResult: UnunifiSelectCreateImportDialogData | undefined = await this.tmp_dialog
+    const selectedResult: UnunifiSelectCreateImportDialogData | undefined = await this.dialog
       .open<UnunifiSelectCreateImportDialogData>(UnunifiSelectCreateImportDialogComponent)
       .closed.toPromise();
 
@@ -129,7 +127,7 @@ export class UnunifiWalletInfrastructureService implements IUnunifiWalletInfrast
   }
 
   private async openUnunifiSelectWalletDialog(): Promise<StoredWallet | undefined> {
-    const selectedStoredWallet: StoredWallet | undefined = await this.tmp_dialog
+    const selectedStoredWallet: StoredWallet | undefined = await this.dialog
       .open<StoredWallet>(UnunifiSelectWalletDialogComponent)
       .closed.toPromise();
     return selectedStoredWallet;
@@ -139,7 +137,7 @@ export class UnunifiWalletInfrastructureService implements IUnunifiWalletInfrast
     (StoredWallet & { mnemonic: string; privateKey: string }) | undefined
   > {
     const privateWallet: (StoredWallet & { mnemonic: string; privateKey: string }) | undefined =
-      await this.tmp_dialog
+      await this.dialog
         .open<StoredWallet & { mnemonic: string; privateKey: string }>(
           UnunifiCreateWalletFormDialogComponent,
         )
@@ -151,7 +149,7 @@ export class UnunifiWalletInfrastructureService implements IUnunifiWalletInfrast
     (StoredWallet & { mnemonic: string; privateKey: string }) | undefined
   > {
     const privateWallet: (StoredWallet & { mnemonic: string; privateKey: string }) | undefined =
-      await this.tmp_dialog
+      await this.dialog
         .open<StoredWallet & { mnemonic: string; privateKey: string }>(
           UnunifiImportWalletWithPrivateKeyFormDialogComponent,
         )
@@ -163,7 +161,7 @@ export class UnunifiWalletInfrastructureService implements IUnunifiWalletInfrast
     (StoredWallet & { mnemonic: string; privateKey: string }) | undefined
   > {
     const privateWallet: (StoredWallet & { mnemonic: string; privateKey: string }) | undefined =
-      await this.tmp_dialog
+      await this.dialog
         .open<StoredWallet & { mnemonic: string; privateKey: string }>(
           UnunifiImportWalletWithMnemonicFormDialogComponent,
         )
@@ -184,7 +182,7 @@ export class UnunifiWalletInfrastructureService implements IUnunifiWalletInfrast
           checked: boolean;
           saved: boolean;
         })
-      | undefined = await this.tmp_dialog
+      | undefined = await this.dialog
       .open<
         StoredWallet & {
           mnemonic: string;
@@ -210,7 +208,7 @@ export class UnunifiWalletInfrastructureService implements IUnunifiWalletInfrast
           checked: boolean;
           saved: boolean;
         })
-      | undefined = await this.tmp_dialog
+      | undefined = await this.dialog
       .open<
         StoredWallet & {
           mnemonic: string;
@@ -226,7 +224,7 @@ export class UnunifiWalletInfrastructureService implements IUnunifiWalletInfrast
   private async openConnectWalletCompletedDialog(
     connectedStoredWallet: StoredWallet,
   ): Promise<void> {
-    await this.tmp_dialog
+    await this.dialog
       .open(ConnectWalletCompletedDialogComponent, { data: connectedStoredWallet })
       .closed.toPromise();
   }
@@ -234,7 +232,7 @@ export class UnunifiWalletInfrastructureService implements IUnunifiWalletInfrast
   private async openUnunifiKeyFormDialog(): Promise<
     (StoredWallet & { privateKey: string }) | undefined
   > {
-    const privateKey: (StoredWallet & { privateKey: string }) | undefined = await this.tmp_dialog
+    const privateKey: (StoredWallet & { privateKey: string }) | undefined = await this.dialog
       .open<StoredWallet & { privateKey: string }>(UnunifiKeyFormDialogComponent)
       .closed.toPromise();
     return privateKey;

--- a/projects/shared/src/lib/models/wallets/wallet.application.service.ts
+++ b/projects/shared/src/lib/models/wallets/wallet.application.service.ts
@@ -6,6 +6,7 @@ import { MetaMaskService } from './metamask/metamask.service';
 import { UnunifiWalletService } from './ununifi-wallet/ununifi-wallet.service';
 import { WalletType, StoredWallet } from './wallet.model';
 import { WalletService } from './wallet.service';
+import { Dialog } from '@angular/cdk/dialog';
 import { Injectable } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
@@ -20,6 +21,7 @@ export class WalletApplicationService {
     private readonly metaMaskService: MetaMaskService,
     private readonly ununifiWalletService: UnunifiWalletService,
     private readonly dialog: MatDialog,
+    private readonly tmp_dialog: Dialog,
     private snackBar: MatSnackBar,
     private loadingDialog: LoadingDialogService,
   ) {}
@@ -95,10 +97,9 @@ export class WalletApplicationService {
   }
 
   async openConnectWalletStartDialog(): Promise<WalletType | undefined> {
-    const selectedWalletType: WalletType = await this.dialog
-      .open(ConnectWalletStartDialogComponent)
-      .afterClosed()
-      .toPromise();
+    const selectedWalletType: WalletType | undefined = await this.tmp_dialog
+      .open<WalletType>(ConnectWalletStartDialogComponent)
+      .closed.toPromise();
     return selectedWalletType;
   }
 

--- a/projects/shared/src/lib/models/wallets/wallet.application.service.ts
+++ b/projects/shared/src/lib/models/wallets/wallet.application.service.ts
@@ -104,9 +104,8 @@ export class WalletApplicationService {
   }
 
   async openConnectWalletCompletedDialog(connectedStoredWallet: StoredWallet): Promise<void> {
-    await this.dialog
+    await this.tmp_dialog
       .open(ConnectWalletCompletedDialogComponent, { data: connectedStoredWallet })
-      .afterClosed()
-      .toPromise();
+      .closed.toPromise();
   }
 }

--- a/projects/shared/src/lib/models/wallets/wallet.application.service.ts
+++ b/projects/shared/src/lib/models/wallets/wallet.application.service.ts
@@ -8,7 +8,6 @@ import { WalletType, StoredWallet } from './wallet.model';
 import { WalletService } from './wallet.service';
 import { Dialog } from '@angular/cdk/dialog';
 import { Injectable } from '@angular/core';
-import { MatDialog } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 
 @Injectable({
@@ -20,8 +19,7 @@ export class WalletApplicationService {
     private readonly keplrService: KeplrService,
     private readonly metaMaskService: MetaMaskService,
     private readonly ununifiWalletService: UnunifiWalletService,
-    private readonly dialog: MatDialog,
-    private readonly tmp_dialog: Dialog,
+    private readonly dialog: Dialog,
     private snackBar: MatSnackBar,
     private loadingDialog: LoadingDialogService,
   ) {}
@@ -97,14 +95,14 @@ export class WalletApplicationService {
   }
 
   async openConnectWalletStartDialog(): Promise<WalletType | undefined> {
-    const selectedWalletType: WalletType | undefined = await this.tmp_dialog
+    const selectedWalletType: WalletType | undefined = await this.dialog
       .open<WalletType>(ConnectWalletStartDialogComponent)
       .closed.toPromise();
     return selectedWalletType;
   }
 
   async openConnectWalletCompletedDialog(connectedStoredWallet: StoredWallet): Promise<void> {
-    await this.tmp_dialog
+    await this.dialog
       .open(ConnectWalletCompletedDialogComponent, { data: connectedStoredWallet })
       .closed.toPromise();
   }

--- a/projects/shared/src/lib/views/dialogs/cosmos/tx/common/tx-fee-confirm-dialog/tx-fee-confirm-dialog.component.html
+++ b/projects/shared/src/lib/views/dialogs/cosmos/tx/common/tx-fee-confirm-dialog/tx-fee-confirm-dialog.component.html
@@ -1,8 +1,8 @@
-<mat-dialog-content>
+<div>
   <div>
     The tx fee will be {{data.fee.amount}}{{data.fee.denom}}.
   </div>
   <div>Are you sure you want to send the tx with the fee?</div>
   <button mat-flat-button class="w-2/5" color="primary" (click)="okToSendTx()">OK</button>
   <button mat-flat-button class="w-2/5" (click)="cancelToSendTx()">Cancel</button>
-</mat-dialog-content>
+</div>

--- a/projects/shared/src/lib/views/dialogs/cosmos/tx/common/tx-fee-confirm-dialog/tx-fee-confirm-dialog.component.ts
+++ b/projects/shared/src/lib/views/dialogs/cosmos/tx/common/tx-fee-confirm-dialog/tx-fee-confirm-dialog.component.ts
@@ -1,5 +1,5 @@
+import { DialogRef, DIALOG_DATA } from '@angular/cdk/dialog';
 import { Component, Inject, OnInit } from '@angular/core';
-import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import cosmosclient from '@cosmos-client/core';
 
 @Component({
@@ -9,15 +9,21 @@ import cosmosclient from '@cosmos-client/core';
 })
 export class TxFeeConfirmDialogComponent implements OnInit {
   constructor(
-    @Inject(MAT_DIALOG_DATA)
+    @Inject(DIALOG_DATA)
     public readonly data: {
       fee: cosmosclient.proto.cosmos.base.v1beta1.ICoin;
       isConfirmed: boolean;
     },
-    private readonly dialogRef: MatDialogRef<TxFeeConfirmDialogComponent>,
-  ) { }
+    private readonly dialogRef: DialogRef<
+      {
+        fee: cosmosclient.proto.cosmos.base.v1beta1.ICoin;
+        isConfirmed: boolean;
+      },
+      TxFeeConfirmDialogComponent
+    >,
+  ) {}
 
-  ngOnInit(): void { }
+  ngOnInit(): void {}
 
   okToSendTx(): void {
     this.data.isConfirmed = true;

--- a/projects/shared/src/lib/views/dialogs/ununifi/tx/nft/list-nft-form-dialog/list-nft-form-dialog.component.html
+++ b/projects/shared/src/lib/views/dialogs/ununifi/tx/nft/list-nft-form-dialog/list-nft-form-dialog.component.html
@@ -1,4 +1,4 @@
-<mat-dialog-content>
+<div>
   <div class="flex flex-col items-center">
     <img class="m-6 w-12 h-12" src="assets/favicon.png" alt="UnUniFi logo" />
     <div class="font-bold text-xl text-white m-3">List NFT to Marketplace</div>
@@ -145,4 +145,4 @@
       List NFT
     </button>
   </form>
-</mat-dialog-content>
+</div>

--- a/projects/shared/src/lib/views/dialogs/ununifi/tx/nft/nft-menu-dialog/nft-menu-dialog.component.html
+++ b/projects/shared/src/lib/views/dialogs/ununifi/tx/nft/nft-menu-dialog/nft-menu-dialog.component.html
@@ -1,4 +1,4 @@
-<mat-dialog-content>
+<div>
   <div class="flex flex-col items-center">
     <img class="m-6 w-12 h-12" src="assets/favicon.png" alt="UnUniFi logo" />
     <div class="font-bold text-xl m-3">NFT Menu</div>
@@ -10,4 +10,4 @@
       <span class="text-black">List NFT to Marketplace</span>
     </button>
 </div>
-</mat-dialog-content>
+</div>

--- a/projects/shared/src/lib/views/dialogs/wallets/connect-wallet-completed-dialog/connect-wallet-completed-dialog.component.html
+++ b/projects/shared/src/lib/views/dialogs/wallets/connect-wallet-completed-dialog/connect-wallet-completed-dialog.component.html
@@ -1,4 +1,4 @@
-<mat-dialog-content>
+<div>
   <div class="flex flex-col items-center">
     <img class="m-6 w-12 h-12" src="assets/favicon.png" alt="UnUniFi logo">
     <div class="font-bold text-white text-xl m-3">Connect Your Wallet</div>
@@ -18,4 +18,4 @@
     </mat-list>
     <button mat-flat-button (click)="onClickButton()">OK</button>
   </div>
-</mat-dialog-content>
+</div>

--- a/projects/shared/src/lib/views/dialogs/wallets/connect-wallet-completed-dialog/connect-wallet-completed-dialog.component.ts
+++ b/projects/shared/src/lib/views/dialogs/wallets/connect-wallet-completed-dialog/connect-wallet-completed-dialog.component.ts
@@ -1,6 +1,6 @@
 import { StoredWallet } from '../../../../../lib/models/wallets/wallet.model';
+import { DialogRef, DIALOG_DATA } from '@angular/cdk/dialog';
 import { Component, Inject, OnInit } from '@angular/core';
-import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import * as crypto from 'crypto';
 
 @Component({
@@ -10,9 +10,9 @@ import * as crypto from 'crypto';
 })
 export class ConnectWalletCompletedDialogComponent implements OnInit {
   constructor(
-    @Inject(MAT_DIALOG_DATA)
+    @Inject(DIALOG_DATA)
     public readonly data: StoredWallet,
-    private readonly dialogRef: MatDialogRef<ConnectWalletCompletedDialogComponent>,
+    private readonly dialogRef: DialogRef<ConnectWalletCompletedDialogComponent>,
   ) {}
 
   ngOnInit(): void {}

--- a/projects/shared/src/lib/views/dialogs/wallets/connect-wallet-start-dialog/connect-wallet-start-dialog.component.html
+++ b/projects/shared/src/lib/views/dialogs/wallets/connect-wallet-start-dialog/connect-wallet-start-dialog.component.html
@@ -1,4 +1,4 @@
-<mat-dialog-content>
+<div>
   <div class="flex flex-col items-center">
     <img class="m-6 w-12 h-12" src="assets/favicon.png" alt="UnUniFi logo" />
     <div class="font-bold text-xl text-white m-3">Connect Your Wallet</div>
@@ -17,4 +17,4 @@
       </button>
     </ng-container>
   </div>
-</mat-dialog-content>
+</div>

--- a/projects/shared/src/lib/views/dialogs/wallets/connect-wallet-start-dialog/connect-wallet-start-dialog.component.ts
+++ b/projects/shared/src/lib/views/dialogs/wallets/connect-wallet-start-dialog/connect-wallet-start-dialog.component.ts
@@ -1,6 +1,6 @@
 import { WalletType } from '../../../../../lib/models/wallets/wallet.model';
+import { DialogRef } from '@angular/cdk/dialog';
 import { Component, OnInit } from '@angular/core';
-import { MatDialogRef } from '@angular/material/dialog';
 
 @Component({
   selector: 'app-connect-wallet-start-dialog',
@@ -36,11 +36,11 @@ export class ConnectWalletStartDialogComponent implements OnInit {
     },
   ];
 
-  constructor(public matDialogRef: MatDialogRef<ConnectWalletStartDialogComponent>) {}
+  constructor(public dialogRef: DialogRef<WalletType, ConnectWalletStartDialogComponent>) {}
 
   ngOnInit(): void {}
 
   onClickButton(walletType: WalletType): void {
-    this.matDialogRef.close(walletType);
+    this.dialogRef.close(walletType);
   }
 }

--- a/projects/shared/src/lib/views/dialogs/wallets/ununifi/ununifi-backup-mnemonic-and-private-key-wizard-dialog/ununifi-backup-mnemonic-and-private-key-wizard-dialog.component.html
+++ b/projects/shared/src/lib/views/dialogs/wallets/ununifi/ununifi-backup-mnemonic-and-private-key-wizard-dialog/ununifi-backup-mnemonic-and-private-key-wizard-dialog.component.html
@@ -1,4 +1,4 @@
-<mat-dialog-content>
+<div>
   <div class="flex flex-col items-center">
     <img class="m-6 w-12 h-12" src="assets/favicon.png" alt="UnUniFi logo">
     <div class="font-bold text-xl text-white m-3">Connect Your Wallet</div>
@@ -43,4 +43,4 @@
       </mat-step>
     </mat-stepper>
   </div>
-</mat-dialog-content>
+</div>

--- a/projects/shared/src/lib/views/dialogs/wallets/ununifi/ununifi-backup-mnemonic-and-private-key-wizard-dialog/ununifi-backup-mnemonic-and-private-key-wizard-dialog.component.ts
+++ b/projects/shared/src/lib/views/dialogs/wallets/ununifi/ununifi-backup-mnemonic-and-private-key-wizard-dialog/ununifi-backup-mnemonic-and-private-key-wizard-dialog.component.ts
@@ -1,7 +1,7 @@
 import { StoredWallet } from '../../../../../../lib/models/wallets/wallet.model';
+import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
 import { STEPPER_GLOBAL_OPTIONS } from '@angular/cdk/stepper';
 import { Component, OnInit, Inject } from '@angular/core';
-import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 
 @Component({
@@ -26,9 +26,17 @@ export class UnunifiBackupMnemonicAndPrivateKeyWizardDialogComponent implements 
   private mnemonicArray = this.data.mnemonic.split(/\s/);
 
   constructor(
-    @Inject(MAT_DIALOG_DATA)
+    @Inject(DIALOG_DATA)
     public readonly data: StoredWallet & { mnemonic: string; privateKey: string },
-    public matDialogRef: MatDialogRef<UnunifiBackupMnemonicAndPrivateKeyWizardDialogComponent>,
+    public dialogRef: DialogRef<
+      StoredWallet & {
+        mnemonic: string;
+        privateKey: string;
+        checked: boolean;
+        saved: boolean;
+      },
+      UnunifiBackupMnemonicAndPrivateKeyWizardDialogComponent
+    >,
     private readonly snackBar: MatSnackBar,
   ) {}
 
@@ -51,7 +59,7 @@ export class UnunifiBackupMnemonicAndPrivateKeyWizardDialogComponent implements 
       checked: this.checked,
       saved: this.saved,
     };
-    this.matDialogRef.close(walletBackupResult);
+    this.dialogRef.close(walletBackupResult);
   }
 
   ordinal(n: number): string {

--- a/projects/shared/src/lib/views/dialogs/wallets/ununifi/ununifi-backup-private-key-wizard-dialog/ununifi-backup-private-key-wizard-dialog.component.html
+++ b/projects/shared/src/lib/views/dialogs/wallets/ununifi/ununifi-backup-private-key-wizard-dialog/ununifi-backup-private-key-wizard-dialog.component.html
@@ -1,5 +1,5 @@
 <p>ununifi-backup-private-key-wizard-dialog works!</p>
-<mat-dialog-content>
+<div>
   <div class="flex flex-col items-center">
     <img class="m-6 w-12 h-12" src="assets/favicon.png" alt="UnUniFi logo" />
     <div class="font-bold text-xl text-white m-3">Connect Your Wallet</div>
@@ -52,4 +52,4 @@
       </mat-step>
     </mat-stepper>
   </div>
-</mat-dialog-content>
+</div>

--- a/projects/shared/src/lib/views/dialogs/wallets/ununifi/ununifi-backup-private-key-wizard-dialog/ununifi-backup-private-key-wizard-dialog.component.ts
+++ b/projects/shared/src/lib/views/dialogs/wallets/ununifi/ununifi-backup-private-key-wizard-dialog/ununifi-backup-private-key-wizard-dialog.component.ts
@@ -1,7 +1,7 @@
 import { StoredWallet } from '../../../../../models/wallets/wallet.model';
+import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
 import { STEPPER_GLOBAL_OPTIONS } from '@angular/cdk/stepper';
 import { Component, OnInit, Inject } from '@angular/core';
-import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 
 @Component({
@@ -25,9 +25,17 @@ export class UnunifiBackupPrivateKeyWizardDialogComponent implements OnInit {
   sec = this.now.getSeconds();
 
   constructor(
-    @Inject(MAT_DIALOG_DATA)
+    @Inject(DIALOG_DATA)
     public readonly data: StoredWallet & { mnemonic: string; privateKey: string },
-    public matDialogRef: MatDialogRef<UnunifiBackupPrivateKeyWizardDialogComponent>,
+    public dialogRef: DialogRef<
+      StoredWallet & {
+        mnemonic: string;
+        privateKey: string;
+        checked: boolean;
+        saved: boolean;
+      },
+      UnunifiBackupPrivateKeyWizardDialogComponent
+    >,
     private readonly snackBar: MatSnackBar,
   ) {}
 
@@ -50,7 +58,7 @@ export class UnunifiBackupPrivateKeyWizardDialogComponent implements OnInit {
       checked: this.checked,
       saved: this.saved,
     };
-    this.matDialogRef.close(walletBackupResult);
+    this.dialogRef.close(walletBackupResult);
   }
 
   savePrivateKey(): void {

--- a/projects/shared/src/lib/views/dialogs/wallets/ununifi/ununifi-create-wallet-form-dialog/ununifi-create-wallet-form-dialog.component.html
+++ b/projects/shared/src/lib/views/dialogs/wallets/ununifi/ununifi-create-wallet-form-dialog/ununifi-create-wallet-form-dialog.component.html
@@ -1,4 +1,4 @@
-<mat-dialog-content>
+<div>
   <div class="flex flex-col items-center">
     <img class="m-6 w-12 h-12" src="assets/favicon.png" alt="UnUniFi logo">
     <div class="font-bold text-white text-xl m-3">Connect Your Wallet</div>
@@ -103,4 +103,4 @@
       </ng-container>
     </ng-container>
   </div>
-</mat-dialog-content>
+</div>

--- a/projects/shared/src/lib/views/dialogs/wallets/ununifi/ununifi-create-wallet-form-dialog/ununifi-create-wallet-form-dialog.component.ts
+++ b/projects/shared/src/lib/views/dialogs/wallets/ununifi/ununifi-create-wallet-form-dialog/ununifi-create-wallet-form-dialog.component.ts
@@ -6,8 +6,8 @@ import {
   createPrivateKeyStringFromMnemonic,
 } from '../../../../../../lib/utils/key';
 import { Clipboard } from '@angular/cdk/clipboard';
+import { DialogRef } from '@angular/cdk/dialog';
 import { Component, OnInit } from '@angular/core';
-import { MatDialogRef } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import cosmosclient from '@cosmos-client/core';
 import * as bip39 from 'bip39';
@@ -23,7 +23,10 @@ export class UnunifiCreateWalletFormDialogComponent implements OnInit {
   wallets$: Promise<StoredWallet[] | undefined>;
 
   constructor(
-    private readonly dialogRef: MatDialogRef<UnunifiCreateWalletFormDialogComponent>,
+    private readonly dialogRef: DialogRef<
+      StoredWallet & { mnemonic: string; privateKey: string },
+      UnunifiCreateWalletFormDialogComponent
+    >,
     private clipboard: Clipboard,
     private readonly snackBar: MatSnackBar,
     private walletService: WalletService,
@@ -56,7 +59,7 @@ export class UnunifiCreateWalletFormDialogComponent implements OnInit {
     });
   }
 
-  ngOnInit(): void { }
+  ngOnInit(): void {}
 
   togglePasswordVisibility() {
     this.isPasswordVisible = !this.isPasswordVisible;

--- a/projects/shared/src/lib/views/dialogs/wallets/ununifi/ununifi-import-wallet-with-mnemonic-form-dialog/ununifi-import-wallet-with-mnemonic-form-dialog.component.html
+++ b/projects/shared/src/lib/views/dialogs/wallets/ununifi/ununifi-import-wallet-with-mnemonic-form-dialog/ununifi-import-wallet-with-mnemonic-form-dialog.component.html
@@ -1,4 +1,4 @@
-<mat-dialog-content>
+<div>
   <div class="flex flex-col items-center">
     <img class="m-6 w-12 h-12" src="assets/favicon.png" alt="UnUniFi logo" />
     <div class="font-bold text-xl text-white m-3">Connect Your Wallet</div>
@@ -100,4 +100,4 @@
       </ng-container>
     </ng-container>
   </div>
-</mat-dialog-content>
+</div>

--- a/projects/shared/src/lib/views/dialogs/wallets/ununifi/ununifi-import-wallet-with-mnemonic-form-dialog/ununifi-import-wallet-with-mnemonic-form-dialog.component.ts
+++ b/projects/shared/src/lib/views/dialogs/wallets/ununifi/ununifi-import-wallet-with-mnemonic-form-dialog/ununifi-import-wallet-with-mnemonic-form-dialog.component.ts
@@ -7,8 +7,8 @@ import {
 } from '../../../../../../lib/utils/key';
 import { validatePrivateStoredWallet } from '../../../../../../lib/utils/validation';
 import { Clipboard } from '@angular/cdk/clipboard';
+import { DialogRef } from '@angular/cdk/dialog';
 import { Component, OnInit } from '@angular/core';
-import { MatDialogRef } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import cosmosclient from '@cosmos-client/core';
 import { BehaviorSubject, combineLatest, Observable, of } from 'rxjs';
@@ -29,7 +29,10 @@ export class UnunifiImportWalletWithMnemonicFormDialogComponent implements OnIni
   wallets$: Observable<StoredWallet[] | null | undefined>;
 
   constructor(
-    private readonly dialogRef: MatDialogRef<UnunifiImportWalletWithMnemonicFormDialogComponent>,
+    private readonly dialogRef: DialogRef<
+      StoredWallet & { mnemonic: string; privateKey: string },
+      UnunifiImportWalletWithMnemonicFormDialogComponent
+    >,
     private clipboard: Clipboard,
     private readonly snackBar: MatSnackBar,
     private walletService: WalletService,
@@ -99,7 +102,7 @@ export class UnunifiImportWalletWithMnemonicFormDialogComponent implements OnIni
     );
   }
 
-  ngOnInit(): void { }
+  ngOnInit(): void {}
 
   togglePasswordVisibility() {
     this.isPasswordVisible = !this.isPasswordVisible;

--- a/projects/shared/src/lib/views/dialogs/wallets/ununifi/ununifi-import-wallet-with-private-key-form-dialog/ununifi-import-wallet-with-private-key-form-dialog.component.html
+++ b/projects/shared/src/lib/views/dialogs/wallets/ununifi/ununifi-import-wallet-with-private-key-form-dialog/ununifi-import-wallet-with-private-key-form-dialog.component.html
@@ -1,4 +1,4 @@
-<mat-dialog-content>
+<div>
   <div class="flex flex-col items-center">
     <img class="m-6 w-12 h-12" src="assets/favicon.png" alt="UnUniFi logo" />
     <div class="font-bold text-xl text-white m-3">Connect Your Wallet</div>
@@ -81,4 +81,4 @@
       </ng-container>
     </ng-container>
   </div>
-</mat-dialog-content>
+</div>

--- a/projects/shared/src/lib/views/dialogs/wallets/ununifi/ununifi-import-wallet-with-private-key-form-dialog/ununifi-import-wallet-with-private-key-form-dialog.component.ts
+++ b/projects/shared/src/lib/views/dialogs/wallets/ununifi/ununifi-import-wallet-with-private-key-form-dialog/ununifi-import-wallet-with-private-key-form-dialog.component.ts
@@ -3,8 +3,8 @@ import { StoredWallet, WalletType } from '../../../../../models/wallets/wallet.m
 import { WalletService } from '../../../../../models/wallets/wallet.service';
 import { createCosmosPrivateKeyFromString } from '../../../../../utils/key';
 import { Clipboard } from '@angular/cdk/clipboard';
+import { DialogRef } from '@angular/cdk/dialog';
 import { Component, OnInit } from '@angular/core';
-import { MatDialogRef } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import cosmosclient from '@cosmos-client/core';
 import { BehaviorSubject, combineLatest, Observable } from 'rxjs';
@@ -25,7 +25,10 @@ export class UnunifiImportWalletWithPrivateKeyFormDialogComponent implements OnI
   wallets$: Observable<StoredWallet[] | null | undefined>;
 
   constructor(
-    private readonly dialogRef: MatDialogRef<UnunifiImportWalletWithPrivateKeyFormDialogComponent>,
+    private readonly dialogRef: DialogRef<
+      StoredWallet & { mnemonic: string; privateKey: string },
+      UnunifiImportWalletWithPrivateKeyFormDialogComponent
+    >,
     private clipboard: Clipboard,
     private readonly snackBar: MatSnackBar,
     private walletService: WalletService,
@@ -86,7 +89,7 @@ export class UnunifiImportWalletWithPrivateKeyFormDialogComponent implements OnI
     );
   }
 
-  ngOnInit(): void { }
+  ngOnInit(): void {}
 
   togglePasswordVisibility() {
     this.isPasswordVisible = !this.isPasswordVisible;

--- a/projects/shared/src/lib/views/dialogs/wallets/ununifi/ununifi-key-form-dialog/ununifi-key-form-dialog.component.html
+++ b/projects/shared/src/lib/views/dialogs/wallets/ununifi/ununifi-key-form-dialog/ununifi-key-form-dialog.component.html
@@ -1,4 +1,4 @@
-<mat-dialog-content>
+<div>
   <div class="flex flex-col items-center">
     <img class="m-6 w-12 h-12" src="assets/favicon.png" alt="UnUniFi logo">
     <div class="font-bold text-xl text-white m-3">Sign Tx</div>
@@ -40,4 +40,4 @@
       </ng-container>
     </ng-container>
   </div>
-</mat-dialog-content>
+</div>

--- a/projects/shared/src/lib/views/dialogs/wallets/ununifi/ununifi-key-form-dialog/ununifi-key-form-dialog.component.ts
+++ b/projects/shared/src/lib/views/dialogs/wallets/ununifi/ununifi-key-form-dialog/ununifi-key-form-dialog.component.ts
@@ -1,7 +1,7 @@
 import { StoredWallet } from '../../../../../../lib/models/wallets/wallet.model';
 import { WalletService } from '../../../../../../lib/models/wallets/wallet.service';
+import { DialogRef } from '@angular/cdk/dialog';
 import { Component, OnInit } from '@angular/core';
-import { MatDialogRef } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 
 @Component({
@@ -14,7 +14,10 @@ export class UnunifiKeyFormDialogComponent implements OnInit {
 
   constructor(
     private readonly walletService: WalletService,
-    private readonly dialogRef: MatDialogRef<UnunifiKeyFormDialogComponent>,
+    private readonly dialogRef: DialogRef<
+      StoredWallet & { privateKey: string },
+      UnunifiKeyFormDialogComponent
+    >,
     private readonly snackBar: MatSnackBar,
   ) {
     this.currentStoredWallet$ = this.walletService.getCurrentStoredWallet();

--- a/projects/shared/src/lib/views/dialogs/wallets/ununifi/ununifi-select-create-import-dialog/ununifi-select-create-import-dialog.component.html
+++ b/projects/shared/src/lib/views/dialogs/wallets/ununifi/ununifi-select-create-import-dialog/ununifi-select-create-import-dialog.component.html
@@ -1,4 +1,4 @@
-<mat-dialog-content>
+<div>
   <div class="flex flex-col items-center">
     <img class="m-6 w-12 h-12" src="assets/favicon.png" alt="UnUniFi logo">
     <div class="font-bold text-xl text-white m-3">Connect Your Wallet</div>
@@ -9,4 +9,4 @@
       </button>
     </ng-container>
   </div>
-</mat-dialog-content>
+</div>

--- a/projects/shared/src/lib/views/dialogs/wallets/ununifi/ununifi-select-create-import-dialog/ununifi-select-create-import-dialog.component.ts
+++ b/projects/shared/src/lib/views/dialogs/wallets/ununifi/ununifi-select-create-import-dialog/ununifi-select-create-import-dialog.component.ts
@@ -1,6 +1,11 @@
+import { DialogRef } from '@angular/cdk/dialog';
 import { Component, OnInit } from '@angular/core';
-import { MatDialogRef } from '@angular/material/dialog';
 
+export type UnunifiSelectCreateImportDialogData =
+  | 'select'
+  | 'import'
+  | 'importWithPrivateKey'
+  | 'create';
 @Component({
   selector: 'view-ununifi-select-create-import-dialog',
   templateUrl: './ununifi-select-create-import-dialog.component.html',
@@ -29,11 +34,16 @@ export class UnunifiSelectCreateImportDialogComponent implements OnInit {
     },
   ];
 
-  constructor(public matDialogRef: MatDialogRef<UnunifiSelectCreateImportDialogComponent>) {}
+  constructor(
+    public dialogRef: DialogRef<
+      UnunifiSelectCreateImportDialogData,
+      UnunifiSelectCreateImportDialogComponent
+    >,
+  ) {}
 
   ngOnInit(): void {}
 
   onClickButton(value: 'select' | 'import' | 'importWithPrivateKey' | 'create'): void {
-    this.matDialogRef.close(value);
+    this.dialogRef.close(value);
   }
 }

--- a/projects/shared/src/lib/views/dialogs/wallets/ununifi/ununifi-select-wallet-dialog/ununifi-select-wallet-dialog.component.html
+++ b/projects/shared/src/lib/views/dialogs/wallets/ununifi/ununifi-select-wallet-dialog/ununifi-select-wallet-dialog.component.html
@@ -1,4 +1,4 @@
-<mat-dialog-content>
+<div>
   <div class="flex flex-col items-center overflow-y-auto">
     <img class="m-6 w-12 h-12" src="assets/favicon.png" alt="UnUniFi logo">
     <div class="font-bold text-xl text-white m-3">Connect Your Wallet</div>
@@ -26,4 +26,4 @@
       </ng-container>
     </ng-container>
   </div>
-</mat-dialog-content>
+</div>

--- a/projects/shared/src/lib/views/dialogs/wallets/ununifi/ununifi-select-wallet-dialog/ununifi-select-wallet-dialog.component.ts
+++ b/projects/shared/src/lib/views/dialogs/wallets/ununifi/ununifi-select-wallet-dialog/ununifi-select-wallet-dialog.component.ts
@@ -1,7 +1,7 @@
 import { StoredWallet, WalletType } from '../../../../../../lib/models/wallets/wallet.model';
 import { WalletService } from '../../../../../../lib/models/wallets/wallet.service';
+import { DialogRef } from '@angular/cdk/dialog';
 import { Component, OnInit } from '@angular/core';
-import { MatDialogRef } from '@angular/material/dialog';
 import * as crypto from 'crypto';
 
 @Component({
@@ -15,7 +15,7 @@ export class UnunifiSelectWalletDialogComponent implements OnInit {
 
   constructor(
     private readonly walletService: WalletService,
-    private readonly dialogRef: MatDialogRef<UnunifiSelectWalletDialogComponent>,
+    private readonly dialogRef: DialogRef<StoredWallet, UnunifiSelectWalletDialogComponent>,
   ) {
     this.storedWallets$ = this.walletService
       .listStoredWallets()

--- a/projects/shared/src/lib/views/material.module.ts
+++ b/projects/shared/src/lib/views/material.module.ts
@@ -1,4 +1,5 @@
 import { ClipboardModule } from '@angular/cdk/clipboard';
+import { DialogModule } from '@angular/cdk/dialog';
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { MatAutocompleteModule } from '@angular/material/autocomplete';
@@ -6,7 +7,6 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import { MatCardModule } from '@angular/material/card';
 import { MatCheckboxModule } from '@angular/material/checkbox';
-import { MatDialogModule } from '@angular/material/dialog';
 import { MatDividerModule } from '@angular/material/divider';
 import { MatExpansionModule } from '@angular/material/expansion';
 import { MatFormFieldModule } from '@angular/material/form-field';
@@ -31,7 +31,7 @@ import { MatToolbarModule } from '@angular/material/toolbar';
     MatButtonModule,
     MatCardModule,
     MatCheckboxModule,
-    MatDialogModule,
+    // DialogModule,
     MatDividerModule,
     MatFormFieldModule,
     MatIconModule,

--- a/projects/shared/src/lib/views/nfts/nft/nft.component.spec.ts
+++ b/projects/shared/src/lib/views/nfts/nft/nft.component.spec.ts
@@ -2,7 +2,6 @@ import { NftTxApplicationService } from '../../../models/ununifi/tx/nft/nft-tx.a
 import { LibViewNftComponent } from './nft.component';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatCardModule } from '@angular/material/card';
-import { MatDialogModule } from '@angular/material/dialog';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { RouterTestingModule } from '@angular/router/testing';
 
@@ -15,7 +14,7 @@ describe('LibViewNftComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [LibViewNftComponent],
-      imports: [RouterTestingModule, MatSnackBarModule, MatDialogModule, MatCardModule],
+      imports: [RouterTestingModule, MatSnackBarModule, MatCardModule],
       providers: [NftTxApplicationService],
     }).compileComponents();
   });

--- a/projects/shared/src/lib/widgets/dialogs/ununifi/tx/list-nft-form-dialog/list-nft-form-dialog.component.ts
+++ b/projects/shared/src/lib/widgets/dialogs/ununifi/tx/list-nft-form-dialog/list-nft-form-dialog.component.ts
@@ -5,8 +5,8 @@ import { NftTxApplicationService } from '../../../../../models/ununifi/tx/nft/nf
 import { StoredWallet } from '../../../../../models/wallets/wallet.model';
 import { WalletService } from '../../../../../models/wallets/wallet.service';
 import { MsgListNftFormData } from '../../../../../views/dialogs/ununifi/tx/nft/list-nft-form-dialog/list-nft-form-dialog.component';
+import { DialogRef, DIALOG_DATA } from '@angular/cdk/dialog';
 import { Component, Inject, OnInit } from '@angular/core';
-import { MatDialog, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import cosmosclient from '@cosmos-client/core';
 import { combineLatest, Observable } from 'rxjs';
@@ -26,15 +26,14 @@ export class LibWidgetListNftFormDialogComponent implements OnInit {
   minimumGasPrices$: Observable<cosmosclient.proto.cosmos.base.v1beta1.ICoin[] | undefined>;
 
   constructor(
-    @Inject(MAT_DIALOG_DATA)
+    @Inject(DIALOG_DATA)
     public readonly data: Nft,
-    public matDialogRef: MatDialogRef<LibWidgetListNftFormDialogComponent>,
+    public dialogRef: DialogRef<string, LibWidgetListNftFormDialogComponent>,
     private readonly cosmosSDK: CosmosSDKService,
     private readonly walletService: WalletService,
     private readonly configS: ConfigService,
     private readonly nftTxAppService: NftTxApplicationService,
     private readonly snackBar: MatSnackBar,
-    private readonly dialog: MatDialog,
   ) {
     this.nft = data;
 
@@ -56,7 +55,7 @@ export class LibWidgetListNftFormDialogComponent implements OnInit {
     this.minimumGasPrices$ = this.configS.config$.pipe(map((config) => config?.minimumGasPrices));
   }
 
-  ngOnInit(): void { }
+  ngOnInit(): void {}
 
   async onSubmit($event: MsgListNftFormData): Promise<void> {
     let txHash: string | undefined;
@@ -67,6 +66,6 @@ export class LibWidgetListNftFormDialogComponent implements OnInit {
       $event.gasSetting.gasRatio,
     );
 
-    this.matDialogRef.close(txHash);
+    this.dialogRef.close(txHash);
   }
 }

--- a/projects/shared/src/lib/widgets/dialogs/ununifi/tx/nft-menu-dialog/nft-menu-dialog.component.ts
+++ b/projects/shared/src/lib/widgets/dialogs/ununifi/tx/nft-menu-dialog/nft-menu-dialog.component.ts
@@ -1,7 +1,7 @@
 import { Nft } from '../../../../../models/ununifi/query/nft/nft.model';
 import { NftTxApplicationService } from '../../../../../models/ununifi/tx/nft/nft-tx.application.service';
+import { DialogRef, DIALOG_DATA } from '@angular/cdk/dialog';
 import { Component, Inject, OnInit } from '@angular/core';
-import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { Router } from '@angular/router';
 
 @Component({
@@ -13,10 +13,10 @@ export class LibWidgetNftMenuDialogComponent implements OnInit {
   nft: Nft;
 
   constructor(
-    @Inject(MAT_DIALOG_DATA)
+    @Inject(DIALOG_DATA)
     public readonly data: Nft,
     private router: Router,
-    public matDialogRef: MatDialogRef<LibWidgetNftMenuDialogComponent>,
+    public dialogRef: DialogRef<LibWidgetNftMenuDialogComponent>,
     private readonly nftTxApplicationService: NftTxApplicationService,
   ) {
     this.nft = data;
@@ -25,7 +25,7 @@ export class LibWidgetNftMenuDialogComponent implements OnInit {
   ngOnInit() {}
 
   async onSubmitListNft(nft: Nft) {
-    this.matDialogRef.close();
+    this.dialogRef.close();
     await this.nftTxApplicationService.openListNftFormDialog(nft);
   }
 }


### PR DESCRIPTION
Dialog to be modified
- marketplace
- shared
  - list nft form dialog
  - nft menu dialog
  - ununifi key form dialog
  - ununifi backup private key wizard dialog
  - ununifi backup mnemonic and private key wizard dialog
  - ununifi import wallet with mnemonic form dialog
  - ununifi import wallet with private key form dialog
  - ununifi create wallet form dialog
  - ununifi select wallet dialog
  - ununifi select create import dialog
  - connect wallet completed dialog
  - connect wallet start dialog

Review Perspective
- Not using angular/material/dialog
- Dialog should work properly