### PR TITLE
refactor: [wallet app dialog]Abolish MatDialog and use Dialog of Angular CDK

### DIFF
--- a/projects/portal/src/app/models/cosmos/gov.application.service.ts
+++ b/projects/portal/src/app/models/cosmos/gov.application.service.ts
@@ -51,7 +51,7 @@ export class GovApplicationService {
     minimumGasPrice: cosmosclient.proto.cosmos.base.v1beta1.ICoin,
     gasRatio: number,
   ) {
-    const privateWallet: StoredWallet & { privateKey: string } =
+    const privateWallet: (StoredWallet & { privateKey: string }) | undefined =
       await this.walletApplicationService.openUnunifiKeyFormDialog();
     if (!privateWallet || !privateWallet.privateKey) {
       this.snackBar.open('Failed to get Wallet info from dialog! Tray again!', 'Close');

--- a/projects/portal/src/app/models/cosmos/staking.application.service.ts
+++ b/projects/portal/src/app/models/cosmos/staking.application.service.ts
@@ -183,7 +183,7 @@ export class StakingApplicationService {
     minimumGasPrice: cosmosclient.proto.cosmos.base.v1beta1.ICoin,
     gasRatio: number,
   ) {
-    const privateWallet: StoredWallet & { privateKey: string } =
+    const privateWallet: (StoredWallet & { privateKey: string }) | undefined =
       await this.walletApplicationService.openUnunifiKeyFormDialog();
     if (!privateWallet || !privateWallet.privateKey) {
       this.snackBar.open('Failed to get Wallet info from dialog! Tray again!', 'Close');
@@ -376,7 +376,7 @@ export class StakingApplicationService {
     gasRatio: number,
     options?: InterfaceValidatorSimpleOptions,
   ) {
-    const privateWallet: StoredWallet & { privateKey: string } =
+    const privateWallet: (StoredWallet & { privateKey: string }) | undefined =
       await this.walletApplicationService.openUnunifiKeyFormDialog();
     if (!privateWallet || !privateWallet.privateKey) {
       this.snackBar.open('Failed to get Wallet info from dialog! Tray again!', 'Close');

--- a/projects/portal/src/app/models/cosmos/tx-common.service.ts
+++ b/projects/portal/src/app/models/cosmos/tx-common.service.ts
@@ -182,7 +182,7 @@ export class TxCommonService {
     if (privateKey) {
       cosmosPrivateKey = createCosmosPrivateKeyFromString(KeyType.secp256k1, privateKey);
     } else {
-      const privateWallet: StoredWallet & { privateKey: string } =
+      const privateWallet: (StoredWallet & { privateKey: string }) | undefined =
         await this.walletAppService.openUnunifiKeyFormDialog();
       if (!privateWallet || !privateWallet.privateKey) {
         this.snackBar.open('Failed to get Wallet info from dialog! Tray again!', 'Close');

--- a/projects/portal/src/app/models/wallets/wallet.application.service.ts
+++ b/projects/portal/src/app/models/wallets/wallet.application.service.ts
@@ -235,10 +235,9 @@ export class WalletApplicationService {
   }
 
   async openUnunifiSelectWalletDialog(): Promise<StoredWallet | undefined> {
-    const selectedStoredWallet: StoredWallet | undefined = await this.dialog
-      .open(UnunifiSelectWalletDialogComponent)
-      .afterClosed()
-      .toPromise();
+    const selectedStoredWallet: StoredWallet | undefined = await this.tmp_dialog
+      .open<StoredWallet>(UnunifiSelectWalletDialogComponent)
+      .closed.toPromise();
     return selectedStoredWallet;
   }
 

--- a/projects/portal/src/app/models/wallets/wallet.application.service.ts
+++ b/projects/portal/src/app/models/wallets/wallet.application.service.ts
@@ -307,15 +307,23 @@ export class WalletApplicationService {
     | (StoredWallet & { mnemonic: string; privateKey: string; checked: boolean; saved: boolean })
     | undefined
   > {
-    const backupResult: StoredWallet & {
-      mnemonic: string;
-      privateKey: string;
-      checked: boolean;
-      saved: boolean;
-    } = await this.dialog
-      .open(UnunifiBackupPrivateKeyWizardDialogComponent, { data: privateWallet })
-      .afterClosed()
-      .toPromise();
+    const backupResult:
+      | (StoredWallet & {
+          mnemonic: string;
+          privateKey: string;
+          checked: boolean;
+          saved: boolean;
+        })
+      | undefined = await this.tmp_dialog
+      .open<
+        StoredWallet & {
+          mnemonic: string;
+          privateKey: string;
+          checked: boolean;
+          saved: boolean;
+        }
+      >(UnunifiBackupPrivateKeyWizardDialogComponent, { data: privateWallet })
+      .closed.toPromise();
     return backupResult;
   }
   async openConnectWalletCompletedDialog(connectedStoredWallet: StoredWallet): Promise<void> {

--- a/projects/portal/src/app/models/wallets/wallet.application.service.ts
+++ b/projects/portal/src/app/models/wallets/wallet.application.service.ts
@@ -6,7 +6,10 @@ import { UnunifiCreateWalletFormDialogComponent } from '../../views/dialogs/wall
 import { UnunifiImportWalletWithMnemonicFormDialogComponent } from '../../views/dialogs/wallets/ununifi/ununifi-import-wallet-with-mnemonic-form-dialog/ununifi-import-wallet-with-mnemonic-form-dialog.component';
 import { UnunifiImportWalletWithPrivateKeyFormDialogComponent } from '../../views/dialogs/wallets/ununifi/ununifi-import-wallet-with-private-key-form-dialog/ununifi-import-wallet-with-private-key-form-dialog.component';
 import { UnunifiKeyFormDialogComponent } from '../../views/dialogs/wallets/ununifi/ununifi-key-form-dialog/ununifi-key-form-dialog.component';
-import { UnunifiSelectCreateImportDialogComponent } from '../../views/dialogs/wallets/ununifi/ununifi-select-create-import-dialog/ununifi-select-create-import-dialog.component';
+import {
+  UnunifiSelectCreateImportDialogData,
+  UnunifiSelectCreateImportDialogComponent,
+} from '../../views/dialogs/wallets/ununifi/ununifi-select-create-import-dialog/ununifi-select-create-import-dialog.component';
 import { UnunifiSelectWalletDialogComponent } from '../../views/dialogs/wallets/ununifi/ununifi-select-wallet-dialog/ununifi-select-wallet-dialog.component';
 import { KeplrService } from './keplr/keplr.service';
 import { MetaMaskService } from './metamask/metamask.service';
@@ -222,10 +225,11 @@ export class WalletApplicationService {
   }
 
   async openUnunifiSelectCreateImportDialog(): Promise<
-    'select' | 'import' | 'importWithPrivateKey' | 'create' | undefined
+    UnunifiSelectCreateImportDialogData | undefined
   > {
-    const selectedResult: 'select' | 'import' | 'importWithPrivateKey' | 'create' | undefined =
-      await this.dialog.open(UnunifiSelectCreateImportDialogComponent).afterClosed().toPromise();
+    const selectedResult: UnunifiSelectCreateImportDialogData | undefined = await this.tmp_dialog
+      .open<UnunifiSelectCreateImportDialogData>(UnunifiSelectCreateImportDialogComponent)
+      .closed.toPromise();
 
     return selectedResult;
   }

--- a/projects/portal/src/app/models/wallets/wallet.application.service.ts
+++ b/projects/portal/src/app/models/wallets/wallet.application.service.ts
@@ -264,10 +264,12 @@ export class WalletApplicationService {
   async openUnunifiImportWalletWithMnemonicDialog(): Promise<
     (StoredWallet & { mnemonic: string; privateKey: string }) | undefined
   > {
-    const privateWallet: StoredWallet & { mnemonic: string; privateKey: string } = await this.dialog
-      .open(UnunifiImportWalletWithMnemonicFormDialogComponent)
-      .afterClosed()
-      .toPromise();
+    const privateWallet: (StoredWallet & { mnemonic: string; privateKey: string }) | undefined =
+      await this.tmp_dialog
+        .open<StoredWallet & { mnemonic: string; privateKey: string }>(
+          UnunifiImportWalletWithMnemonicFormDialogComponent,
+        )
+        .closed.toPromise();
     return privateWallet;
   }
 

--- a/projects/portal/src/app/models/wallets/wallet.application.service.ts
+++ b/projects/portal/src/app/models/wallets/wallet.application.service.ts
@@ -254,10 +254,12 @@ export class WalletApplicationService {
   async openUnunifiImportWalletWithPrivateKeyDialog(): Promise<
     (StoredWallet & { mnemonic: string; privateKey: string }) | undefined
   > {
-    const privateWallet: StoredWallet & { mnemonic: string; privateKey: string } = await this.dialog
-      .open(UnunifiImportWalletWithPrivateKeyFormDialogComponent)
-      .afterClosed()
-      .toPromise();
+    const privateWallet: (StoredWallet & { mnemonic: string; privateKey: string }) | undefined =
+      await this.tmp_dialog
+        .open<StoredWallet & { mnemonic: string; privateKey: string }>(
+          UnunifiImportWalletWithPrivateKeyFormDialogComponent,
+        )
+        .closed.toPromise();
     return privateWallet;
   }
 

--- a/projects/portal/src/app/models/wallets/wallet.application.service.ts
+++ b/projects/portal/src/app/models/wallets/wallet.application.service.ts
@@ -244,10 +244,12 @@ export class WalletApplicationService {
   async openUnunifiCreateWalletDialog(): Promise<
     (StoredWallet & { mnemonic: string; privateKey: string }) | undefined
   > {
-    const privateWallet: StoredWallet & { mnemonic: string; privateKey: string } = await this.dialog
-      .open(UnunifiCreateWalletFormDialogComponent)
-      .afterClosed()
-      .toPromise();
+    const privateWallet: (StoredWallet & { mnemonic: string; privateKey: string }) | undefined =
+      await this.tmp_dialog
+        .open<StoredWallet & { mnemonic: string; privateKey: string }>(
+          UnunifiCreateWalletFormDialogComponent,
+        )
+        .closed.toPromise();
     return privateWallet;
   }
 

--- a/projects/portal/src/app/models/wallets/wallet.application.service.ts
+++ b/projects/portal/src/app/models/wallets/wallet.application.service.ts
@@ -279,15 +279,23 @@ export class WalletApplicationService {
     | (StoredWallet & { mnemonic: string; privateKey: string; checked: boolean; saved: boolean })
     | undefined
   > {
-    const backupResult: StoredWallet & {
-      mnemonic: string;
-      privateKey: string;
-      checked: boolean;
-      saved: boolean;
-    } = await this.dialog
-      .open(UnunifiBackupMnemonicAndPrivateKeyWizardDialogComponent, { data: privateWallet })
-      .afterClosed()
-      .toPromise();
+    const backupResult:
+      | (StoredWallet & {
+          mnemonic: string;
+          privateKey: string;
+          checked: boolean;
+          saved: boolean;
+        })
+      | undefined = await this.tmp_dialog
+      .open<
+        StoredWallet & {
+          mnemonic: string;
+          privateKey: string;
+          checked: boolean;
+          saved: boolean;
+        }
+      >(UnunifiBackupMnemonicAndPrivateKeyWizardDialogComponent, { data: privateWallet })
+      .closed.toPromise();
     return backupResult;
   }
 

--- a/projects/portal/src/app/models/wallets/wallet.application.service.ts
+++ b/projects/portal/src/app/models/wallets/wallet.application.service.ts
@@ -17,7 +17,6 @@ import { WalletType, StoredWallet } from './wallet.model';
 import { WalletService } from './wallet.service';
 import { Dialog } from '@angular/cdk/dialog';
 import { Injectable } from '@angular/core';
-import { MatDialog } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { LoadingDialogService } from 'projects/shared/src/lib/components/loading-dialog';
 
@@ -29,8 +28,7 @@ export class WalletApplicationService {
     private readonly walletService: WalletService,
     private readonly keplrService: KeplrService,
     private readonly metaMaskService: MetaMaskService,
-    private readonly dialog: MatDialog,
-    private readonly tmp_dialog: Dialog,
+    private readonly dialog: Dialog,
     private snackBar: MatSnackBar,
     private loadingDialog: LoadingDialogService,
   ) {}
@@ -218,7 +216,7 @@ export class WalletApplicationService {
   }
 
   async openConnectWalletStartDialog(): Promise<WalletType | undefined> {
-    const selectedWalletType: WalletType | undefined = await this.tmp_dialog
+    const selectedWalletType: WalletType | undefined = await this.dialog
       .open<WalletType>(ConnectWalletStartDialogComponent)
       .closed.toPromise();
     return selectedWalletType;
@@ -227,7 +225,7 @@ export class WalletApplicationService {
   async openUnunifiSelectCreateImportDialog(): Promise<
     UnunifiSelectCreateImportDialogData | undefined
   > {
-    const selectedResult: UnunifiSelectCreateImportDialogData | undefined = await this.tmp_dialog
+    const selectedResult: UnunifiSelectCreateImportDialogData | undefined = await this.dialog
       .open<UnunifiSelectCreateImportDialogData>(UnunifiSelectCreateImportDialogComponent)
       .closed.toPromise();
 
@@ -235,7 +233,7 @@ export class WalletApplicationService {
   }
 
   async openUnunifiSelectWalletDialog(): Promise<StoredWallet | undefined> {
-    const selectedStoredWallet: StoredWallet | undefined = await this.tmp_dialog
+    const selectedStoredWallet: StoredWallet | undefined = await this.dialog
       .open<StoredWallet>(UnunifiSelectWalletDialogComponent)
       .closed.toPromise();
     return selectedStoredWallet;
@@ -245,7 +243,7 @@ export class WalletApplicationService {
     (StoredWallet & { mnemonic: string; privateKey: string }) | undefined
   > {
     const privateWallet: (StoredWallet & { mnemonic: string; privateKey: string }) | undefined =
-      await this.tmp_dialog
+      await this.dialog
         .open<StoredWallet & { mnemonic: string; privateKey: string }>(
           UnunifiCreateWalletFormDialogComponent,
         )
@@ -257,7 +255,7 @@ export class WalletApplicationService {
     (StoredWallet & { mnemonic: string; privateKey: string }) | undefined
   > {
     const privateWallet: (StoredWallet & { mnemonic: string; privateKey: string }) | undefined =
-      await this.tmp_dialog
+      await this.dialog
         .open<StoredWallet & { mnemonic: string; privateKey: string }>(
           UnunifiImportWalletWithPrivateKeyFormDialogComponent,
         )
@@ -269,7 +267,7 @@ export class WalletApplicationService {
     (StoredWallet & { mnemonic: string; privateKey: string }) | undefined
   > {
     const privateWallet: (StoredWallet & { mnemonic: string; privateKey: string }) | undefined =
-      await this.tmp_dialog
+      await this.dialog
         .open<StoredWallet & { mnemonic: string; privateKey: string }>(
           UnunifiImportWalletWithMnemonicFormDialogComponent,
         )
@@ -290,7 +288,7 @@ export class WalletApplicationService {
           checked: boolean;
           saved: boolean;
         })
-      | undefined = await this.tmp_dialog
+      | undefined = await this.dialog
       .open<
         StoredWallet & {
           mnemonic: string;
@@ -316,7 +314,7 @@ export class WalletApplicationService {
           checked: boolean;
           saved: boolean;
         })
-      | undefined = await this.tmp_dialog
+      | undefined = await this.dialog
       .open<
         StoredWallet & {
           mnemonic: string;
@@ -329,13 +327,13 @@ export class WalletApplicationService {
     return backupResult;
   }
   async openConnectWalletCompletedDialog(connectedStoredWallet: StoredWallet): Promise<void> {
-    await this.tmp_dialog
+    await this.dialog
       .open(ConnectWalletCompletedDialogComponent, { data: connectedStoredWallet })
       .closed.toPromise();
   }
 
   async openUnunifiKeyFormDialog(): Promise<(StoredWallet & { privateKey: string }) | undefined> {
-    const privateKey = await this.tmp_dialog
+    const privateKey = await this.dialog
       .open<StoredWallet & { privateKey: string }>(UnunifiKeyFormDialogComponent)
       .closed.toPromise();
     return privateKey;

--- a/projects/portal/src/app/models/wallets/wallet.application.service.ts
+++ b/projects/portal/src/app/models/wallets/wallet.application.service.ts
@@ -12,6 +12,7 @@ import { KeplrService } from './keplr/keplr.service';
 import { MetaMaskService } from './metamask/metamask.service';
 import { WalletType, StoredWallet } from './wallet.model';
 import { WalletService } from './wallet.service';
+import { Dialog } from '@angular/cdk/dialog';
 import { Injectable } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
@@ -26,6 +27,7 @@ export class WalletApplicationService {
     private readonly keplrService: KeplrService,
     private readonly metaMaskService: MetaMaskService,
     private readonly dialog: MatDialog,
+    private readonly tmp_dialog: Dialog,
     private snackBar: MatSnackBar,
     private loadingDialog: LoadingDialogService,
   ) {}
@@ -213,10 +215,9 @@ export class WalletApplicationService {
   }
 
   async openConnectWalletStartDialog(): Promise<WalletType | undefined> {
-    const selectedWalletType: WalletType = await this.dialog
-      .open(ConnectWalletStartDialogComponent)
-      .afterClosed()
-      .toPromise();
+    const selectedWalletType: WalletType | undefined = await this.tmp_dialog
+      .open<WalletType>(ConnectWalletStartDialogComponent)
+      .closed.toPromise();
     return selectedWalletType;
   }
 

--- a/projects/portal/src/app/models/wallets/wallet.application.service.ts
+++ b/projects/portal/src/app/models/wallets/wallet.application.service.ts
@@ -307,10 +307,9 @@ export class WalletApplicationService {
     return backupResult;
   }
   async openConnectWalletCompletedDialog(connectedStoredWallet: StoredWallet): Promise<void> {
-    await this.dialog
+    await this.tmp_dialog
       .open(ConnectWalletCompletedDialogComponent, { data: connectedStoredWallet })
-      .afterClosed()
-      .toPromise();
+      .closed.toPromise();
   }
 
   async openUnunifiKeyFormDialog(): Promise<StoredWallet & { privateKey: string }> {

--- a/projects/portal/src/app/models/wallets/wallet.application.service.ts
+++ b/projects/portal/src/app/models/wallets/wallet.application.service.ts
@@ -334,11 +334,10 @@ export class WalletApplicationService {
       .closed.toPromise();
   }
 
-  async openUnunifiKeyFormDialog(): Promise<StoredWallet & { privateKey: string }> {
-    const privateKey = await this.dialog
-      .open(UnunifiKeyFormDialogComponent)
-      .afterClosed()
-      .toPromise();
+  async openUnunifiKeyFormDialog(): Promise<(StoredWallet & { privateKey: string }) | undefined> {
+    const privateKey = await this.tmp_dialog
+      .open<StoredWallet & { privateKey: string }>(UnunifiKeyFormDialogComponent)
+      .closed.toPromise();
     return privateKey;
   }
 }

--- a/projects/portal/src/app/views/dialogs/wallets/connect-wallet-completed-dialog/connect-wallet-completed-dialog.component.html
+++ b/projects/portal/src/app/views/dialogs/wallets/connect-wallet-completed-dialog/connect-wallet-completed-dialog.component.html
@@ -1,4 +1,4 @@
-<mat-dialog-content>
+<div>
   <div class="flex flex-col items-center">
     <img class="m-6 w-12 h-12" src="assets/favicon.png" alt="UnUniFi logo">
     <div class="font-bold text-xl m-3">Connect Your Wallet</div>
@@ -18,4 +18,4 @@
     </mat-list>
     <button mat-flat-button (click)="onClickButton()">OK</button>
   </div>
-</mat-dialog-content>
+</div>

--- a/projects/portal/src/app/views/dialogs/wallets/connect-wallet-completed-dialog/connect-wallet-completed-dialog.component.ts
+++ b/projects/portal/src/app/views/dialogs/wallets/connect-wallet-completed-dialog/connect-wallet-completed-dialog.component.ts
@@ -1,6 +1,6 @@
 import { StoredWallet } from './../../../../models/wallets/wallet.model';
+import { DialogRef, DIALOG_DATA } from '@angular/cdk/dialog';
 import { Component, Inject, OnInit } from '@angular/core';
-import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import * as crypto from 'crypto';
 
 @Component({
@@ -10,9 +10,9 @@ import * as crypto from 'crypto';
 })
 export class ConnectWalletCompletedDialogComponent implements OnInit {
   constructor(
-    @Inject(MAT_DIALOG_DATA)
+    @Inject(DIALOG_DATA)
     public readonly data: StoredWallet,
-    private readonly dialogRef: MatDialogRef<ConnectWalletCompletedDialogComponent>,
+    private readonly dialogRef: DialogRef<ConnectWalletCompletedDialogComponent>,
   ) {}
 
   ngOnInit(): void {}

--- a/projects/portal/src/app/views/dialogs/wallets/connect-wallet-start-dialog/connect-wallet-start-dialog.component.html
+++ b/projects/portal/src/app/views/dialogs/wallets/connect-wallet-start-dialog/connect-wallet-start-dialog.component.html
@@ -1,4 +1,4 @@
-<mat-dialog-content>
+<div>
   <div class="flex flex-col items-center">
     <img class="m-6 w-12 h-12" src="assets/favicon.png" alt="UnUniFi logo" />
     <div class="font-bold text-xl m-3">Connect Your Wallet</div>
@@ -17,4 +17,4 @@
       </button>
     </ng-container>
   </div>
-</mat-dialog-content>
+</div>

--- a/projects/portal/src/app/views/dialogs/wallets/connect-wallet-start-dialog/connect-wallet-start-dialog.component.ts
+++ b/projects/portal/src/app/views/dialogs/wallets/connect-wallet-start-dialog/connect-wallet-start-dialog.component.ts
@@ -1,6 +1,6 @@
 import { WalletType } from './../../../../models/wallets/wallet.model';
+import { DialogRef } from '@angular/cdk/dialog';
 import { Component, OnInit } from '@angular/core';
-import { MatDialogRef } from '@angular/material/dialog';
 
 @Component({
   selector: 'app-connect-wallet-start-dialog',
@@ -36,11 +36,11 @@ export class ConnectWalletStartDialogComponent implements OnInit {
     },
   ];
 
-  constructor(public matDialogRef: MatDialogRef<ConnectWalletStartDialogComponent>) {}
+  constructor(public dialogRef: DialogRef<WalletType, ConnectWalletStartDialogComponent>) {}
 
   ngOnInit(): void {}
 
   onClickButton(walletType: WalletType): void {
-    this.matDialogRef.close(walletType);
+    this.dialogRef.close(walletType);
   }
 }

--- a/projects/portal/src/app/views/dialogs/wallets/ununifi/ununifi-backup-mnemonic-and-private-key-wizard-dialog/ununifi-backup-mnemonic-and-private-key-wizard-dialog.component.html
+++ b/projects/portal/src/app/views/dialogs/wallets/ununifi/ununifi-backup-mnemonic-and-private-key-wizard-dialog/ununifi-backup-mnemonic-and-private-key-wizard-dialog.component.html
@@ -1,4 +1,4 @@
-<mat-dialog-content>
+<div>
   <div class="flex flex-col items-center">
     <img class="m-6 w-12 h-12" src="assets/favicon.png" alt="UnUniFi logo">
     <div class="font-bold text-xl m-3">Connect Your Wallet</div>
@@ -43,4 +43,4 @@
       </mat-step>
     </mat-stepper>
   </div>
-</mat-dialog-content>
+</div>

--- a/projects/portal/src/app/views/dialogs/wallets/ununifi/ununifi-backup-mnemonic-and-private-key-wizard-dialog/ununifi-backup-mnemonic-and-private-key-wizard-dialog.component.ts
+++ b/projects/portal/src/app/views/dialogs/wallets/ununifi/ununifi-backup-mnemonic-and-private-key-wizard-dialog/ununifi-backup-mnemonic-and-private-key-wizard-dialog.component.ts
@@ -1,6 +1,6 @@
+import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
 import { STEPPER_GLOBAL_OPTIONS } from '@angular/cdk/stepper';
 import { Component, OnInit, Inject } from '@angular/core';
-import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { StoredWallet } from 'projects/portal/src/app/models/wallets/wallet.model';
 
@@ -26,9 +26,17 @@ export class UnunifiBackupMnemonicAndPrivateKeyWizardDialogComponent implements 
   private mnemonicArray = this.data.mnemonic.split(/\s/);
 
   constructor(
-    @Inject(MAT_DIALOG_DATA)
+    @Inject(DIALOG_DATA)
     public readonly data: StoredWallet & { mnemonic: string; privateKey: string },
-    public matDialogRef: MatDialogRef<UnunifiBackupMnemonicAndPrivateKeyWizardDialogComponent>,
+    public dialogRef: DialogRef<
+      StoredWallet & {
+        mnemonic: string;
+        privateKey: string;
+        checked: boolean;
+        saved: boolean;
+      },
+      UnunifiBackupMnemonicAndPrivateKeyWizardDialogComponent
+    >,
     private readonly snackBar: MatSnackBar,
   ) {}
 
@@ -51,7 +59,7 @@ export class UnunifiBackupMnemonicAndPrivateKeyWizardDialogComponent implements 
       checked: this.checked,
       saved: this.saved,
     };
-    this.matDialogRef.close(walletBackupResult);
+    this.dialogRef.close(walletBackupResult);
   }
 
   ordinal(n: number): string {

--- a/projects/portal/src/app/views/dialogs/wallets/ununifi/ununifi-backup-private-key-wizard-dialog/ununifi-backup-private-key-wizard-dialog.component.html
+++ b/projects/portal/src/app/views/dialogs/wallets/ununifi/ununifi-backup-private-key-wizard-dialog/ununifi-backup-private-key-wizard-dialog.component.html
@@ -1,5 +1,5 @@
 <p>ununifi-backup-private-key-wizard-dialog works!</p>
-<mat-dialog-content>
+<div>
   <div class="flex flex-col items-center">
     <img class="m-6 w-12 h-12" src="assets/favicon.png" alt="UnUniFi logo" />
     <div class="font-bold text-xl m-3">Connect Your Wallet</div>
@@ -52,4 +52,4 @@
       </mat-step>
     </mat-stepper>
   </div>
-</mat-dialog-content>
+</div>

--- a/projects/portal/src/app/views/dialogs/wallets/ununifi/ununifi-backup-private-key-wizard-dialog/ununifi-backup-private-key-wizard-dialog.component.ts
+++ b/projects/portal/src/app/views/dialogs/wallets/ununifi/ununifi-backup-private-key-wizard-dialog/ununifi-backup-private-key-wizard-dialog.component.ts
@@ -1,6 +1,6 @@
+import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
 import { STEPPER_GLOBAL_OPTIONS } from '@angular/cdk/stepper';
 import { Component, OnInit, Inject } from '@angular/core';
-import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { StoredWallet } from 'projects/portal/src/app/models/wallets/wallet.model';
 
@@ -25,13 +25,21 @@ export class UnunifiBackupPrivateKeyWizardDialogComponent implements OnInit {
   sec = this.now.getSeconds();
 
   constructor(
-    @Inject(MAT_DIALOG_DATA)
+    @Inject(DIALOG_DATA)
     public readonly data: StoredWallet & { mnemonic: string; privateKey: string },
-    public matDialogRef: MatDialogRef<UnunifiBackupPrivateKeyWizardDialogComponent>,
+    public dialogRef: DialogRef<
+      StoredWallet & {
+        mnemonic: string;
+        privateKey: string;
+        checked: boolean;
+        saved: boolean;
+      },
+      UnunifiBackupPrivateKeyWizardDialogComponent
+    >,
     private readonly snackBar: MatSnackBar,
-  ) { }
+  ) {}
 
-  ngOnInit(): void { }
+  ngOnInit(): void {}
 
   onClickSubmit(): void {
     const walletBackupResult: StoredWallet & {
@@ -50,7 +58,7 @@ export class UnunifiBackupPrivateKeyWizardDialogComponent implements OnInit {
       checked: this.checked,
       saved: this.saved,
     };
-    this.matDialogRef.close(walletBackupResult);
+    this.dialogRef.close(walletBackupResult);
   }
 
   savePrivateKey(): void {

--- a/projects/portal/src/app/views/dialogs/wallets/ununifi/ununifi-create-wallet-form-dialog/ununifi-create-wallet-form-dialog.component.html
+++ b/projects/portal/src/app/views/dialogs/wallets/ununifi/ununifi-create-wallet-form-dialog/ununifi-create-wallet-form-dialog.component.html
@@ -1,4 +1,4 @@
-<mat-dialog-content>
+<div>
   <div class="flex flex-col items-center">
     <img class="m-6 w-12 h-12" src="assets/favicon.png" alt="UnUniFi logo">
     <div class="font-bold text-xl m-3">Connect Your Wallet</div>
@@ -103,4 +103,4 @@
       </ng-container>
     </ng-container>
   </div>
-</mat-dialog-content>
+</div>

--- a/projects/portal/src/app/views/dialogs/wallets/ununifi/ununifi-create-wallet-form-dialog/ununifi-create-wallet-form-dialog.component.ts
+++ b/projects/portal/src/app/views/dialogs/wallets/ununifi/ununifi-create-wallet-form-dialog/ununifi-create-wallet-form-dialog.component.ts
@@ -6,8 +6,8 @@ import {
   createPrivateKeyStringFromMnemonic,
 } from './../../../../../utils/key';
 import { Clipboard } from '@angular/cdk/clipboard';
+import { DialogRef } from '@angular/cdk/dialog';
 import { Component, OnInit } from '@angular/core';
-import { MatDialogRef } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import cosmosclient from '@cosmos-client/core';
 import * as bip39 from 'bip39';
@@ -23,7 +23,10 @@ export class UnunifiCreateWalletFormDialogComponent implements OnInit {
   wallets$: Promise<StoredWallet[] | undefined>;
 
   constructor(
-    private readonly dialogRef: MatDialogRef<UnunifiCreateWalletFormDialogComponent>,
+    private readonly dialogRef: DialogRef<
+      StoredWallet & { mnemonic: string; privateKey: string },
+      UnunifiCreateWalletFormDialogComponent
+    >,
     private clipboard: Clipboard,
     private readonly snackBar: MatSnackBar,
     private walletService: WalletService,

--- a/projects/portal/src/app/views/dialogs/wallets/ununifi/ununifi-import-wallet-with-mnemonic-form-dialog/ununifi-import-wallet-with-mnemonic-form-dialog.component.html
+++ b/projects/portal/src/app/views/dialogs/wallets/ununifi/ununifi-import-wallet-with-mnemonic-form-dialog/ununifi-import-wallet-with-mnemonic-form-dialog.component.html
@@ -1,4 +1,4 @@
-<mat-dialog-content>
+<div>
   <div class="flex flex-col items-center">
     <img class="m-6 w-12 h-12" src="assets/favicon.png" alt="UnUniFi logo" />
     <div class="font-bold text-xl m-3">Connect Your Wallet</div>
@@ -100,4 +100,4 @@
       </ng-container>
     </ng-container>
   </div>
-</mat-dialog-content>
+</div>

--- a/projects/portal/src/app/views/dialogs/wallets/ununifi/ununifi-import-wallet-with-mnemonic-form-dialog/ununifi-import-wallet-with-mnemonic-form-dialog.component.ts
+++ b/projects/portal/src/app/views/dialogs/wallets/ununifi/ununifi-import-wallet-with-mnemonic-form-dialog/ununifi-import-wallet-with-mnemonic-form-dialog.component.ts
@@ -7,8 +7,8 @@ import { KeyType } from './../../../../../models/keys/key.model';
 import { StoredWallet, WalletType } from './../../../../../models/wallets/wallet.model';
 import { WalletService } from './../../../../../models/wallets/wallet.service';
 import { Clipboard } from '@angular/cdk/clipboard';
+import { DialogRef } from '@angular/cdk/dialog';
 import { Component, OnInit } from '@angular/core';
-import { MatDialogRef } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import cosmosclient from '@cosmos-client/core';
 import { BehaviorSubject, combineLatest, Observable, of } from 'rxjs';
@@ -29,7 +29,10 @@ export class UnunifiImportWalletWithMnemonicFormDialogComponent implements OnIni
   wallets$: Observable<StoredWallet[] | null | undefined>;
 
   constructor(
-    private readonly dialogRef: MatDialogRef<UnunifiImportWalletWithMnemonicFormDialogComponent>,
+    private readonly dialogRef: DialogRef<
+      StoredWallet & { mnemonic: string; privateKey: string },
+      UnunifiImportWalletWithMnemonicFormDialogComponent
+    >,
     private clipboard: Clipboard,
     private readonly snackBar: MatSnackBar,
     private walletService: WalletService,

--- a/projects/portal/src/app/views/dialogs/wallets/ununifi/ununifi-import-wallet-with-private-key-form-dialog/ununifi-import-wallet-with-private-key-form-dialog.component.html
+++ b/projects/portal/src/app/views/dialogs/wallets/ununifi/ununifi-import-wallet-with-private-key-form-dialog/ununifi-import-wallet-with-private-key-form-dialog.component.html
@@ -1,4 +1,4 @@
-<mat-dialog-content>
+<div>
   <div class="flex flex-col items-center">
     <img class="m-6 w-12 h-12" src="assets/favicon.png" alt="UnUniFi logo" />
     <div class="font-bold text-xl m-3">Connect Your Wallet</div>
@@ -81,4 +81,4 @@
       </ng-container>
     </ng-container>
   </div>
-</mat-dialog-content>
+</div>

--- a/projects/portal/src/app/views/dialogs/wallets/ununifi/ununifi-import-wallet-with-private-key-form-dialog/ununifi-import-wallet-with-private-key-form-dialog.component.ts
+++ b/projects/portal/src/app/views/dialogs/wallets/ununifi/ununifi-import-wallet-with-private-key-form-dialog/ununifi-import-wallet-with-private-key-form-dialog.component.ts
@@ -3,8 +3,8 @@ import { StoredWallet, WalletType } from './../../../../../models/wallets/wallet
 import { WalletService } from './../../../../../models/wallets/wallet.service';
 import { createCosmosPrivateKeyFromString } from './../../../../../utils/key';
 import { Clipboard } from '@angular/cdk/clipboard';
+import { DialogRef } from '@angular/cdk/dialog';
 import { Component, OnInit } from '@angular/core';
-import { MatDialogRef } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import cosmosclient from '@cosmos-client/core';
 import { BehaviorSubject, combineLatest, Observable } from 'rxjs';
@@ -25,7 +25,10 @@ export class UnunifiImportWalletWithPrivateKeyFormDialogComponent implements OnI
   wallets$: Observable<StoredWallet[] | null | undefined>;
 
   constructor(
-    private readonly dialogRef: MatDialogRef<UnunifiImportWalletWithPrivateKeyFormDialogComponent>,
+    private readonly dialogRef: DialogRef<
+      StoredWallet & { mnemonic: string; privateKey: string },
+      UnunifiImportWalletWithPrivateKeyFormDialogComponent
+    >,
     private clipboard: Clipboard,
     private readonly snackBar: MatSnackBar,
     private walletService: WalletService,

--- a/projects/portal/src/app/views/dialogs/wallets/ununifi/ununifi-key-form-dialog/ununifi-key-form-dialog.component.html
+++ b/projects/portal/src/app/views/dialogs/wallets/ununifi/ununifi-key-form-dialog/ununifi-key-form-dialog.component.html
@@ -1,4 +1,4 @@
-<mat-dialog-content>
+<div>
   <div class="flex flex-col items-center">
     <img class="m-6 w-12 h-12" src="assets/favicon.png" alt="UnUniFi logo">
     <div class="font-bold text-xl m-3">Sign Tx</div>
@@ -40,4 +40,4 @@
       </ng-container>
     </ng-container>
   </div>
-</mat-dialog-content>
+</div>

--- a/projects/portal/src/app/views/dialogs/wallets/ununifi/ununifi-key-form-dialog/ununifi-key-form-dialog.component.ts
+++ b/projects/portal/src/app/views/dialogs/wallets/ununifi/ununifi-key-form-dialog/ununifi-key-form-dialog.component.ts
@@ -1,7 +1,7 @@
 import { StoredWallet } from './../../../../../models/wallets/wallet.model';
 import { WalletService } from './../../../../../models/wallets/wallet.service';
+import { DialogRef } from '@angular/cdk/dialog';
 import { Component, OnInit } from '@angular/core';
-import { MatDialogRef } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 
 @Component({
@@ -14,7 +14,10 @@ export class UnunifiKeyFormDialogComponent implements OnInit {
 
   constructor(
     private readonly walletService: WalletService,
-    private readonly dialogRef: MatDialogRef<UnunifiKeyFormDialogComponent>,
+    private readonly dialogRef: DialogRef<
+      StoredWallet & { privateKey: string },
+      UnunifiKeyFormDialogComponent
+    >,
     private readonly snackBar: MatSnackBar,
   ) {
     this.currentStoredWallet$ = this.walletService.getCurrentStoredWallet();

--- a/projects/portal/src/app/views/dialogs/wallets/ununifi/ununifi-select-create-import-dialog/ununifi-select-create-import-dialog.component.html
+++ b/projects/portal/src/app/views/dialogs/wallets/ununifi/ununifi-select-create-import-dialog/ununifi-select-create-import-dialog.component.html
@@ -1,4 +1,4 @@
-<mat-dialog-content>
+<div>
   <div class="flex flex-col items-center">
     <img class="m-6 w-12 h-12" src="assets/favicon.png" alt="UnUniFi logo">
     <div class="font-bold text-xl m-3">Connect Your Wallet</div>
@@ -9,4 +9,4 @@
       </button>
     </ng-container>
   </div>
-</mat-dialog-content>
+</div>

--- a/projects/portal/src/app/views/dialogs/wallets/ununifi/ununifi-select-create-import-dialog/ununifi-select-create-import-dialog.component.ts
+++ b/projects/portal/src/app/views/dialogs/wallets/ununifi/ununifi-select-create-import-dialog/ununifi-select-create-import-dialog.component.ts
@@ -1,6 +1,11 @@
+import { DialogRef } from '@angular/cdk/dialog';
 import { Component, OnInit } from '@angular/core';
-import { MatDialogRef } from '@angular/material/dialog';
 
+export type UnunifiSelectCreateImportDialogData =
+  | 'select'
+  | 'import'
+  | 'importWithPrivateKey'
+  | 'create';
 @Component({
   selector: 'view-ununifi-select-create-import-dialog',
   templateUrl: './ununifi-select-create-import-dialog.component.html',
@@ -8,7 +13,7 @@ import { MatDialogRef } from '@angular/material/dialog';
 })
 export class UnunifiSelectCreateImportDialogComponent implements OnInit {
   options: {
-    value: 'select' | 'import' | 'importWithPrivateKey' | 'create';
+    value: UnunifiSelectCreateImportDialogData;
     name: string;
   }[] = [
     {
@@ -29,11 +34,16 @@ export class UnunifiSelectCreateImportDialogComponent implements OnInit {
     },
   ];
 
-  constructor(public matDialogRef: MatDialogRef<UnunifiSelectCreateImportDialogComponent>) {}
+  constructor(
+    public dialogRef: DialogRef<
+      UnunifiSelectCreateImportDialogData,
+      UnunifiSelectCreateImportDialogComponent
+    >,
+  ) {}
 
   ngOnInit(): void {}
 
-  onClickButton(value: 'select' | 'import' | 'importWithPrivateKey' | 'create'): void {
-    this.matDialogRef.close(value);
+  onClickButton(value: UnunifiSelectCreateImportDialogData): void {
+    this.dialogRef.close(value);
   }
 }

--- a/projects/portal/src/app/views/dialogs/wallets/ununifi/ununifi-select-wallet-dialog/ununifi-select-wallet-dialog.component.html
+++ b/projects/portal/src/app/views/dialogs/wallets/ununifi/ununifi-select-wallet-dialog/ununifi-select-wallet-dialog.component.html
@@ -1,4 +1,4 @@
-<mat-dialog-content>
+<div>
   <div class="flex flex-col items-center overflow-y-auto">
     <img class="m-6 w-12 h-12" src="assets/favicon.png" alt="UnUniFi logo">
     <div class="font-bold text-xl m-3">Connect Your Wallet</div>
@@ -26,4 +26,4 @@
       </ng-container>
     </ng-container>
   </div>
-</mat-dialog-content>
+</div>

--- a/projects/portal/src/app/views/dialogs/wallets/ununifi/ununifi-select-wallet-dialog/ununifi-select-wallet-dialog.component.ts
+++ b/projects/portal/src/app/views/dialogs/wallets/ununifi/ununifi-select-wallet-dialog/ununifi-select-wallet-dialog.component.ts
@@ -1,7 +1,7 @@
 import { StoredWallet, WalletType } from './../../../../../models/wallets/wallet.model';
 import { WalletService } from './../../../../../models/wallets/wallet.service';
+import { DialogRef } from '@angular/cdk/dialog';
 import { Component, OnInit } from '@angular/core';
-import { MatDialogRef } from '@angular/material/dialog';
 import * as crypto from 'crypto';
 
 @Component({
@@ -15,7 +15,7 @@ export class UnunifiSelectWalletDialogComponent implements OnInit {
 
   constructor(
     private readonly walletService: WalletService,
-    private readonly dialogRef: MatDialogRef<UnunifiSelectWalletDialogComponent>,
+    private readonly dialogRef: DialogRef<StoredWallet, UnunifiSelectWalletDialogComponent>,
   ) {
     this.storedWallets$ = this.walletService
       .listStoredWallets()

--- a/projects/portal/src/styles.css
+++ b/projects/portal/src/styles.css
@@ -32,3 +32,10 @@ mat-progress-spinner {
 mat-dialog-container {
   background: #3734B0 !important;
 }
+
+cdk-dialog-container {
+  display: block;
+  background: #3734B0 !important;
+  border-radius: 4px;
+  padding: 24px;
+}

--- a/projects/portal/src/styles.css
+++ b/projects/portal/src/styles.css
@@ -35,7 +35,7 @@ mat-dialog-container {
 
 cdk-dialog-container {
   display: block;
-  background: #3734B0 !important;
+  background: #ffffff !important;
   border-radius: 4px;
   padding: 24px;
 }


### PR DESCRIPTION
Dialog to be modified
- portal
   - ununifi key form dialog
  - ununifi create wallet form dialog
  - ununifi backup private key wizard dialog
  - ununifi import wallet with private key form dialog
  - ununifi bakup mnemonic and private key wizard dialog
  - ununifi import wallet with mnemonic form dialog
  - connect wallet completed dialog
  - ununifi select wallet dialog
  - ununifi select import dialog
  - connect wallet start dialog
 
Review Perspective
- Not using angular/material/dialog
- Dialog should work properly