### PR TITLE
fix: tx-mode block => sync

### DIFF
--- a/projects/portal/src/app/models/cosmos/tx-common.service.ts
+++ b/projects/portal/src/app/models/cosmos/tx-common.service.ts
@@ -319,7 +319,7 @@ export class TxCommonService {
     // broadcast tx
     const result = await cosmosclient.rest.tx.broadcastTx(sdk, {
       tx_bytes: txBuilder.txBytes(),
-      mode: cosmosclient.rest.tx.BroadcastTxMode.Block,
+      mode: cosmosclient.rest.tx.BroadcastTxMode.Sync,
     });
 
     // check broadcast tx error

--- a/projects/shared/src/lib/models/cosmos/tx/common/tx-common.service.ts
+++ b/projects/shared/src/lib/models/cosmos/tx/common/tx-common.service.ts
@@ -277,7 +277,7 @@ export class TxCommonService {
     // broadcast tx
     const result = await cosmosclient.rest.tx.broadcastTx(sdk, {
       tx_bytes: txBuilder.txBytes(),
-      mode: cosmosclient.rest.tx.BroadcastTxMode.Block,
+      mode: cosmosclient.rest.tx.BroadcastTxMode.Sync,
     });
 
     // check broadcast tx error


### PR DESCRIPTION
Tx Briadcast mode change
After sdk v0.47.x, merge this branch.
Block => Sync
```
Broadcast mode block was deprecated and has been removed. Please use sync mode instead. When upgrading your tests from block to sync and checking for a transaction code, you need to query the transaction first (with its hash) to get the correct code.
```
https://github.com/cosmos/cosmos-sdk/blob/v0.47.0/UPGRADING.md#broadcast-mode