### PR TITLE
fix: tx include block

### DIFF
--- a/projects/portal/src/app/models/cosmos/tx-common.service.ts
+++ b/projects/portal/src/app/models/cosmos/tx-common.service.ts
@@ -11,7 +11,11 @@ import { SimulatedTxResultResponse } from './tx-common.model';
 import { Injectable } from '@angular/core';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import cosmosclient from '@cosmos-client/core';
-import { BroadcastTx200Response } from '@cosmos-client/core/esm/openapi';
+import {
+  BroadcastTx200Response,
+  CosmosTxV1beta1GetTxResponse,
+  GetLatestBlock200Response,
+} from '@cosmos-client/core/esm/openapi';
 import Long from 'long';
 
 @Injectable({
@@ -328,6 +332,18 @@ export class TxCommonService {
     }
 
     return result.data;
+  }
+
+  async getTx(hash: string): Promise<CosmosTxV1beta1GetTxResponse> {
+    const sdk = await this.cosmosSDK.sdk().then((sdk) => sdk.rest);
+    const res = await cosmosclient.rest.tx.getTx(sdk, hash);
+    return res.data;
+  }
+
+  async getLatestBlock(): Promise<GetLatestBlock200Response> {
+    const sdk = await this.cosmosSDK.sdk().then((sdk) => sdk.rest);
+    const res = await cosmosclient.rest.tendermint.getLatestBlock(sdk);
+    return res.data;
   }
 
   numberToDecString(num: number) {


### PR DESCRIPTION
close #493
The Tx mode block has been eliminated in v47.
This PR checks the block in which Tx is located and waits until the latest height catches up with it further.

@KimuraYu45z 
Please check.
Should I add a timeout for Tx jams?