### PR TITLE
Osmosis Pool APR from API

### DIFF
--- a/projects/explorer/editions/ununifi/launch/ununifi-test/firebase-hosting/config.js
+++ b/projects/explorer/editions/ununifi/launch/ununifi-test/firebase-hosting/config.js
@@ -191,7 +191,10 @@ const strategiesInfo = [
     name: 'Osmosis ATOM/OSMO Farm',
     description: '',
     gitUrl: '',
-    apy: 0.11,
+    poolInfo: {
+      type: 'osmosis',
+      poolId: '1',
+    },
   },
 ];
 

--- a/projects/portal/editions/ununifi/launch/ununifi-test/firebase-hosting/config.js
+++ b/projects/portal/editions/ununifi/launch/ununifi-test/firebase-hosting/config.js
@@ -191,7 +191,10 @@ const strategiesInfo = [
     name: 'Osmosis ATOM/OSMO Farm',
     description: '',
     gitUrl: '',
-    apy: 0.11,
+    poolInfo: {
+      type: 'osmosis',
+      poolId: '1',
+    },
   },
 ];
 

--- a/projects/portal/src/app/models/config.service.ts
+++ b/projects/portal/src/app/models/config.service.ts
@@ -56,6 +56,18 @@ export type StrategyInfo = {
   description: string;
   gitURL: string;
   apy: number;
+  poolInfo:
+    | {
+        type: 'osmosis';
+        poolId: string;
+      }
+    | {
+        type: 'osmosis_multi';
+        pools: { id: string; weight: string }[];
+      }
+    | {
+        type: 'astroport';
+      };
 };
 
 declare const configs: Config[];

--- a/projects/portal/src/app/models/yield-aggregators/yield-aggregator.model.ts
+++ b/projects/portal/src/app/models/yield-aggregators/yield-aggregator.model.ts
@@ -26,3 +26,16 @@ export type TransferVaultRequest = {
   vaultId: string;
   recipientAddress: string;
 };
+
+export type OsmosisPools = {
+  pool_id: number;
+  apr_list: {
+    start_date: string;
+    denom: string;
+    symbol: string;
+    apr_1d: number;
+    apr_7d: number;
+    apr_14d: number;
+    apr_superfluid: number;
+  }[];
+}[];

--- a/projects/portal/src/app/pages/yieldaggregator/strategies/strategy/strategy.component.html
+++ b/projects/portal/src/app/pages/yieldaggregator/strategies/strategy/strategy.component.html
@@ -5,5 +5,5 @@
   [symbolImage]="symbolImage$ | async"
   [vaults]="vaults$ | async"
   [weights]="weights$ | async"
-  [strategyInfo]="strategyInfo$ | async"
+  [strategyAPR]="strategyAPR$ | async"
 ></view-strategy>

--- a/projects/portal/src/app/pages/yieldaggregator/vaults/vault/vault.component.ts
+++ b/projects/portal/src/app/pages/yieldaggregator/vaults/vault/vault.component.ts
@@ -150,15 +150,16 @@ export class VaultComponent implements OnInit {
       }),
     );
     this.vaultAPY$ = combineLatest([this.vault$, this.configService.config$]).pipe(
-      map(([vault, config]) => {
+      mergeMap(async ([vault, config]) => {
         if (!vault.vault?.strategy_weights) {
           return 0;
         }
         let vaultAPY = 0;
         for (const strategyWeight of vault.vault.strategy_weights) {
-          const strategyAPY = config?.strategiesInfo?.find(
+          const strategyInfo = config?.strategiesInfo?.find(
             (strategyInfo) => strategyInfo.id === strategyWeight.strategy_id,
-          )?.apy;
+          );
+          const strategyAPY = await this.iyaService.getStrategyAPR(strategyInfo);
           vaultAPY += Number(strategyAPY) * Number(strategyWeight.weight);
         }
         return vaultAPY;

--- a/projects/portal/src/app/views/yieldaggregator/strategies/strategy/strategy.component.html
+++ b/projects/portal/src/app/views/yieldaggregator/strategies/strategy/strategy.component.html
@@ -34,11 +34,11 @@
             </tr>
             <tr>
               <td>Contract Address</td>
-              <td class="font-mono">{{ strategy?.contract_address }}</td>
+              <td class="font-mono break-all">{{ strategy?.contract_address }}</td>
             </tr>
             <tr>
               <td>Git URL</td>
-              <td>
+              <td class="break-all">
                 <a href="{{ strategy?.git_url }}" target="_blank">{{ strategy?.git_url }}</a>
               </td>
             </tr>
@@ -48,7 +48,7 @@
         <div class="stats flex flex-col md:flex-row">
           <div class="stat">
             <div class="stat-title">APR</div>
-            <div class="stat-value text-secondary">{{ strategyInfo?.apy | percent : '1.2-2' }}</div>
+            <div class="stat-value text-secondary">{{ strategyAPR | percent : '1.2-2' }}</div>
             <div class="stat-desc"></div>
           </div>
         </div>

--- a/projects/portal/src/app/views/yieldaggregator/strategies/strategy/strategy.component.ts
+++ b/projects/portal/src/app/views/yieldaggregator/strategies/strategy/strategy.component.ts
@@ -8,7 +8,6 @@ import {
   ViewChild,
 } from '@angular/core';
 import { ChartType } from 'angular-google-charts';
-import { StrategyInfo } from 'projects/portal/src/app/models/config.service';
 import { YieldAggregatorChartService } from 'projects/portal/src/app/models/yield-aggregators/yield-aggregator.chart.service';
 import {
   StrategyAll200ResponseStrategiesInner,
@@ -34,7 +33,7 @@ export class StrategyComponent implements OnInit, OnChanges {
   @Input()
   weights?: (string | undefined)[] | null;
   @Input()
-  strategyInfo?: StrategyInfo | null;
+  strategyAPR?: number | null;
 
   description: string;
   chartType: ChartType;

--- a/projects/portal/src/app/views/yieldaggregator/vaults/vault/vault.component.html
+++ b/projects/portal/src/app/views/yieldaggregator/vaults/vault/vault.component.html
@@ -49,7 +49,7 @@
               </tr>
               <tr>
                 <td>Vault Address</td>
-                <td class="font-mono">{{ vault?.vault_address }}</td>
+                <td class="font-mono break-all">{{ vault?.vault_address }}</td>
               </tr>
               <!-- <tr>
                 <td>Vault Name</td>
@@ -57,7 +57,7 @@
               </tr> -->
               <tr>
                 <td>Owner</td>
-                <td>{{ vault?.vault?.owner }}</td>
+                <td class="font-mono break-all">{{ vault?.vault?.owner }}</td>
               </tr>
               <tr>
                 <td>Owner's Deposit</td>

--- a/projects/portal/src/assets/config.js
+++ b/projects/portal/src/assets/config.js
@@ -5,13 +5,14 @@ const faucetUguuPort = location.protocol === 'https:' ? 8003 : 8002;
 const faucetJpuPort = location.protocol === 'https:' ? 8005 : 8004;
 const faucetUethPort = location.protocol === 'https:' ? 8007 : 8006;
 const faucetEuuPort = location.protocol === 'https:' ? 8009 : 8008;
-const developerPort = location.protocol === 'https:' ? 3040 : 3030;
 
-// To Do write chain config
-const domainCauchyEA = 'ununifi-alpha-test.cauchye.net';
+const domainCauchyEA = 'a.ununifi-test-v1.cauchye.net';
+const domainCauchyEB = 'b.ununifi-test-v1.cauchye.net';
+const domainCauchyEC = 'c.ununifi-test-v1.cauchye.net';
+const domainCauchyED = 'd.ununifi-test-v1.cauchye.net';
 
-const chainID = 'ununifi-alpha-test';
-const chainName = 'UnUniFi (alpha-test)';
+const chainID = 'ununifi-test-v1';
+const chainName = 'UnUniFi (test)';
 
 const bech32Prefix = {
   accAddr: 'ununifi',
@@ -168,6 +169,33 @@ const denomMetadata = [
     display: 'dlp',
     symbol: 'DLP',
   },
+  {
+    description: 'ATOM from Osmosis (testnet)',
+    denom_units: [
+      {
+        denom: 'ibc/ACBD2CEFAC2CC3ED6EEAF67BBDFDF168F1E4EDA159DFE1CA6B4A57A9CAF4DA11',
+        exponent: 0,
+        aliases: [],
+      },
+    ],
+    base: 'ibc/ACBD2CEFAC2CC3ED6EEAF67BBDFDF168F1E4EDA159DFE1CA6B4A57A9CAF4DA11',
+    name: 'ATOM (from Osmosis)',
+    display: 'atom(from osmosis)',
+    symbol: 'ATOM (from Osmosis)',
+  },
+];
+
+const strategiesInfo = [
+  {
+    id: '0',
+    name: 'Osmosis ATOM/OSMO Farm',
+    description: '',
+    gitUrl: '',
+    poolInfo: {
+      type: 'osmosis',
+      poolId: '1',
+    },
+  },
 ];
 
 const configs = [
@@ -186,6 +214,7 @@ const configs = [
       },
     ],
     denomMetadata,
+    strategiesInfo,
     extension: {
       faucet: [
         {
@@ -211,14 +240,141 @@ const configs = [
         },
       ],
       monitor: undefined,
-      nftMint: {
-        enabled: true,
-        nftClasses: ['ununifi-1AFC3C85B52311F13161F724B284EF900458E3B3'],
+      navigations: [],
+      messageModules,
+    },
+  },
+  // CauchyE B node without Monitor
+  {
+    id: domainCauchyEB,
+    restURL: `${location.protocol}//${domainCauchyEB}:${restPort}`,
+    websocketURL: `${location.protocol.replace('http', 'ws')}//${domainCauchyEB}:${websocketPort}`,
+    chainID,
+    chainName,
+    bech32Prefix,
+    minimumGasPrices: [
+      {
+        denom: 'uguu',
+        amount: 0.015,
       },
-      developer: {
-        enabled: true,
-        developerURL: `${location.protocol}//${domainCauchyEA}:${developerPort}`,
+    ],
+    denomMetadata,
+    strategiesInfo,
+    extension: {
+      faucet: [
+        {
+          hasFaucet: true,
+          faucetURL: `${location.protocol}//${domainCauchyEB}:${faucetUbtcPort}`,
+          denom: 'ubtc',
+          creditAmount: 2000000, // amount to credit in max request
+          maxCredit: 2000000, // account has already maxCredit balance cannot claim anymore
+        },
+        {
+          hasFaucet: true,
+          faucetURL: `${location.protocol}//${domainCauchyEB}:${faucetUguuPort}`,
+          denom: 'uguu',
+          creditAmount: 2000000000,
+          maxCredit: 2000000000,
+        },
+        {
+          hasFaucet: true,
+          faucetURL: `${location.protocol}//${domainCauchyEB}:${faucetUguuPort}`,
+          denom: 'uusdc',
+          creditAmount: 2000000000,
+          maxCredit: 2000000000,
+        },
+      ],
+      monitor: undefined,
+      navigations: [],
+      messageModules,
+    },
+  },
+  // CauchyE C node without Monitor
+  {
+    id: domainCauchyEC,
+    restURL: `${location.protocol}//${domainCauchyEC}:${restPort}`,
+    websocketURL: `${location.protocol.replace('http', 'ws')}//${domainCauchyEC}:${websocketPort}`,
+    chainID,
+    chainName,
+    bech32Prefix,
+    minimumGasPrices: [
+      {
+        denom: 'uguu',
+        amount: 0.015,
       },
+    ],
+    denomMetadata,
+    strategiesInfo,
+    extension: {
+      faucet: [
+        {
+          hasFaucet: true,
+          faucetURL: `${location.protocol}//${domainCauchyEC}:${faucetUbtcPort}`,
+          denom: 'ubtc',
+          creditAmount: 2000000, // amount to credit in max request
+          maxCredit: 2000000, // account has already maxCredit balance cannot claim anymore
+        },
+        {
+          hasFaucet: true,
+          faucetURL: `${location.protocol}//${domainCauchyEC}:${faucetUguuPort}`,
+          denom: 'uguu',
+          creditAmount: 2000000000,
+          maxCredit: 2000000000,
+        },
+        {
+          hasFaucet: true,
+          faucetURL: `${location.protocol}//${domainCauchyEC}:${faucetUguuPort}`,
+          denom: 'uusdc',
+          creditAmount: 2000000000,
+          maxCredit: 2000000000,
+        },
+      ],
+      monitor: undefined,
+      navigations: [],
+      messageModules,
+    },
+  },
+  // CauchyE D node without Monitor
+  {
+    id: domainCauchyED,
+    restURL: `${location.protocol}//${domainCauchyED}:${restPort}`,
+    websocketURL: `${location.protocol.replace('http', 'ws')}//${domainCauchyED}:${websocketPort}`,
+    chainID,
+    chainName,
+    bech32Prefix,
+    minimumGasPrices: [
+      {
+        denom: 'uguu',
+        amount: 0.015,
+      },
+    ],
+    denomMetadata,
+    strategiesInfo,
+    extension: {
+      faucet: [
+        {
+          hasFaucet: true,
+          faucetURL: `${location.protocol}//${domainCauchyED}:${faucetUbtcPort}`,
+          denom: 'ubtc',
+          creditAmount: 2000000, // amount to credit in max request
+          maxCredit: 2000000, // account has already maxCredit balance cannot claim anymore
+        },
+        {
+          hasFaucet: true,
+          faucetURL: `${location.protocol}//${domainCauchyED}:${faucetUguuPort}`,
+          denom: 'uguu',
+          creditAmount: 2000000000,
+          maxCredit: 2000000000,
+        },
+        {
+          hasFaucet: true,
+          faucetURL: `${location.protocol}//${domainCauchyED}:${faucetUguuPort}`,
+          denom: 'uusdc',
+          creditAmount: 2000000000,
+          maxCredit: 2000000000,
+        },
+      ],
+      monitor: undefined,
       navigations: [],
       messageModules,
     },

--- a/projects/portal/src/assets/config.js
+++ b/projects/portal/src/assets/config.js
@@ -5,14 +5,13 @@ const faucetUguuPort = location.protocol === 'https:' ? 8003 : 8002;
 const faucetJpuPort = location.protocol === 'https:' ? 8005 : 8004;
 const faucetUethPort = location.protocol === 'https:' ? 8007 : 8006;
 const faucetEuuPort = location.protocol === 'https:' ? 8009 : 8008;
+const developerPort = location.protocol === 'https:' ? 3040 : 3030;
 
-const domainCauchyEA = 'a.ununifi-test-v1.cauchye.net';
-const domainCauchyEB = 'b.ununifi-test-v1.cauchye.net';
-const domainCauchyEC = 'c.ununifi-test-v1.cauchye.net';
-const domainCauchyED = 'd.ununifi-test-v1.cauchye.net';
+// To Do write chain config
+const domainCauchyEA = 'ununifi-alpha-test.cauchye.net';
 
-const chainID = 'ununifi-test-v1';
-const chainName = 'UnUniFi (test)';
+const chainID = 'ununifi-alpha-test';
+const chainName = 'UnUniFi (alpha-test)';
 
 const bech32Prefix = {
   accAddr: 'ununifi',
@@ -169,33 +168,6 @@ const denomMetadata = [
     display: 'dlp',
     symbol: 'DLP',
   },
-  {
-    description: 'ATOM from Osmosis (testnet)',
-    denom_units: [
-      {
-        denom: 'ibc/ACBD2CEFAC2CC3ED6EEAF67BBDFDF168F1E4EDA159DFE1CA6B4A57A9CAF4DA11',
-        exponent: 0,
-        aliases: [],
-      },
-    ],
-    base: 'ibc/ACBD2CEFAC2CC3ED6EEAF67BBDFDF168F1E4EDA159DFE1CA6B4A57A9CAF4DA11',
-    name: 'ATOM (from Osmosis)',
-    display: 'atom(from osmosis)',
-    symbol: 'ATOM (from Osmosis)',
-  },
-];
-
-const strategiesInfo = [
-  {
-    id: '0',
-    name: 'Osmosis ATOM/OSMO Farm',
-    description: '',
-    gitUrl: '',
-    poolInfo: {
-      type: 'osmosis',
-      poolId: '1',
-    },
-  },
 ];
 
 const configs = [
@@ -214,7 +186,6 @@ const configs = [
       },
     ],
     denomMetadata,
-    strategiesInfo,
     extension: {
       faucet: [
         {
@@ -240,141 +211,14 @@ const configs = [
         },
       ],
       monitor: undefined,
-      navigations: [],
-      messageModules,
-    },
-  },
-  // CauchyE B node without Monitor
-  {
-    id: domainCauchyEB,
-    restURL: `${location.protocol}//${domainCauchyEB}:${restPort}`,
-    websocketURL: `${location.protocol.replace('http', 'ws')}//${domainCauchyEB}:${websocketPort}`,
-    chainID,
-    chainName,
-    bech32Prefix,
-    minimumGasPrices: [
-      {
-        denom: 'uguu',
-        amount: 0.015,
+      nftMint: {
+        enabled: true,
+        nftClasses: ['ununifi-1AFC3C85B52311F13161F724B284EF900458E3B3'],
       },
-    ],
-    denomMetadata,
-    strategiesInfo,
-    extension: {
-      faucet: [
-        {
-          hasFaucet: true,
-          faucetURL: `${location.protocol}//${domainCauchyEB}:${faucetUbtcPort}`,
-          denom: 'ubtc',
-          creditAmount: 2000000, // amount to credit in max request
-          maxCredit: 2000000, // account has already maxCredit balance cannot claim anymore
-        },
-        {
-          hasFaucet: true,
-          faucetURL: `${location.protocol}//${domainCauchyEB}:${faucetUguuPort}`,
-          denom: 'uguu',
-          creditAmount: 2000000000,
-          maxCredit: 2000000000,
-        },
-        {
-          hasFaucet: true,
-          faucetURL: `${location.protocol}//${domainCauchyEB}:${faucetUguuPort}`,
-          denom: 'uusdc',
-          creditAmount: 2000000000,
-          maxCredit: 2000000000,
-        },
-      ],
-      monitor: undefined,
-      navigations: [],
-      messageModules,
-    },
-  },
-  // CauchyE C node without Monitor
-  {
-    id: domainCauchyEC,
-    restURL: `${location.protocol}//${domainCauchyEC}:${restPort}`,
-    websocketURL: `${location.protocol.replace('http', 'ws')}//${domainCauchyEC}:${websocketPort}`,
-    chainID,
-    chainName,
-    bech32Prefix,
-    minimumGasPrices: [
-      {
-        denom: 'uguu',
-        amount: 0.015,
+      developer: {
+        enabled: true,
+        developerURL: `${location.protocol}//${domainCauchyEA}:${developerPort}`,
       },
-    ],
-    denomMetadata,
-    strategiesInfo,
-    extension: {
-      faucet: [
-        {
-          hasFaucet: true,
-          faucetURL: `${location.protocol}//${domainCauchyEC}:${faucetUbtcPort}`,
-          denom: 'ubtc',
-          creditAmount: 2000000, // amount to credit in max request
-          maxCredit: 2000000, // account has already maxCredit balance cannot claim anymore
-        },
-        {
-          hasFaucet: true,
-          faucetURL: `${location.protocol}//${domainCauchyEC}:${faucetUguuPort}`,
-          denom: 'uguu',
-          creditAmount: 2000000000,
-          maxCredit: 2000000000,
-        },
-        {
-          hasFaucet: true,
-          faucetURL: `${location.protocol}//${domainCauchyEC}:${faucetUguuPort}`,
-          denom: 'uusdc',
-          creditAmount: 2000000000,
-          maxCredit: 2000000000,
-        },
-      ],
-      monitor: undefined,
-      navigations: [],
-      messageModules,
-    },
-  },
-  // CauchyE D node without Monitor
-  {
-    id: domainCauchyED,
-    restURL: `${location.protocol}//${domainCauchyED}:${restPort}`,
-    websocketURL: `${location.protocol.replace('http', 'ws')}//${domainCauchyED}:${websocketPort}`,
-    chainID,
-    chainName,
-    bech32Prefix,
-    minimumGasPrices: [
-      {
-        denom: 'uguu',
-        amount: 0.015,
-      },
-    ],
-    denomMetadata,
-    strategiesInfo,
-    extension: {
-      faucet: [
-        {
-          hasFaucet: true,
-          faucetURL: `${location.protocol}//${domainCauchyED}:${faucetUbtcPort}`,
-          denom: 'ubtc',
-          creditAmount: 2000000, // amount to credit in max request
-          maxCredit: 2000000, // account has already maxCredit balance cannot claim anymore
-        },
-        {
-          hasFaucet: true,
-          faucetURL: `${location.protocol}//${domainCauchyED}:${faucetUguuPort}`,
-          denom: 'uguu',
-          creditAmount: 2000000000,
-          maxCredit: 2000000000,
-        },
-        {
-          hasFaucet: true,
-          faucetURL: `${location.protocol}//${domainCauchyED}:${faucetUguuPort}`,
-          denom: 'uusdc',
-          creditAmount: 2000000000,
-          maxCredit: 2000000000,
-        },
-      ],
-      monitor: undefined,
       navigations: [],
       messageModules,
     },


### PR DESCRIPTION
## Osmosis Pool APR

Change the APR of the Osmosis pool from hard-coded to API

Endpoint https://api-osmosis.imperator.co/apr/v2/1
Ref https://api-osmosis.imperator.co/swagger/#/apr/apr_per_pool_id

Currently, the sum of apr_superfluid is displayed as APR. Should be improved if there is a bette one.