### PR TITLE
fix: quorum

### DIFF
--- a/projects/portal/src/app/pages/vote/proposals/proposal/proposal.component.ts
+++ b/projects/portal/src/app/pages/vote/proposals/proposal/proposal.component.ts
@@ -2,7 +2,6 @@ import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import cosmosclient from '@cosmos-client/core';
 import {
-  AllBalances200ResponseBalancesInner,
   Deposits200ResponseDepositsInner,
   GovParams200ResponseDepositParams,
   GovParams200ResponseTallyParams,
@@ -29,7 +28,6 @@ export class ProposalComponent implements OnInit {
   tallyParams$: Observable<GovParams200ResponseTallyParams | undefined>;
   votes$: Observable<GovV1Votes200ResponseVotesInner[] | undefined>;
   votingParams$: Observable<GovParams200ResponseVotingParams | undefined>;
-  totalSupply$: Observable<AllBalances200ResponseBalancesInner | undefined>;
   tallyTotalCount$: Observable<number>;
   quorum$: Observable<number>;
   threshold$: Observable<number>;
@@ -102,9 +100,9 @@ export class ProposalComponent implements OnInit {
       }),
     );
 
-    this.totalSupply$ = this.cosmosSDK.sdk$.pipe(
-      mergeMap((sdk) => cosmosclient.rest.bank.totalSupply(sdk.rest)),
-      map((result) => result.data.supply?.find((supply) => supply.denom === 'uguu')),
+    const pool$ = this.cosmosSDK.sdk$.pipe(
+      mergeMap((sdk) => cosmosclient.rest.staking.pool(sdk.rest)),
+      map((result) => result.data.pool),
     );
 
     this.tallyTotalCount$ = this.tally$.pipe(
@@ -117,8 +115,8 @@ export class ProposalComponent implements OnInit {
       ),
     );
 
-    this.quorum$ = combineLatest([this.tallyTotalCount$, this.totalSupply$]).pipe(
-      map(([tallyTotalCount, totalSupply]) => tallyTotalCount / Number(totalSupply?.amount)),
+    this.quorum$ = combineLatest([this.tallyTotalCount$, pool$]).pipe(
+      map(([tallyTotalCount, pool]) => tallyTotalCount / Number(pool?.bonded_tokens)),
     );
     this.threshold$ = this.tally$.pipe(
       map(

--- a/projects/portal/src/app/views/vote/proposals/proposal/proposal.component.ts
+++ b/projects/portal/src/app/views/vote/proposals/proposal/proposal.component.ts
@@ -1,5 +1,4 @@
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
-import cosmosclient from '@cosmos-client/core';
+import { Component, EventEmitter, Input, OnChanges, OnInit, Output } from '@angular/core';
 import {
   GovV1Proposal200ResponseProposalsInner,
   Deposits200ResponseDepositsInner,
@@ -15,7 +14,7 @@ import {
   templateUrl: './proposal.component.html',
   styleUrls: ['./proposal.component.css'],
 })
-export class ProposalComponent implements OnInit {
+export class ProposalComponent implements OnInit, OnChanges {
   @Input()
   proposal?: GovV1Proposal200ResponseProposalsInner | null;
   @Input()
@@ -56,6 +55,13 @@ export class ProposalComponent implements OnInit {
   }
 
   ngOnInit(): void {}
+
+  ngOnChanges(): void {
+    this.quorumNotReached = (this.quorum || 0) < Number(this.tallyParams?.quorum);
+    this.thresholdNotReached = (this.threshold || 0) < Number(this.tallyParams?.threshold);
+    this.vetoThresholdReached =
+      (this.vetoThreshold || 0) > Number(this.tallyParams?.veto_threshold);
+  }
 
   calcTallyRatio(tallyCount?: string) {
     if (!this.tallyTotalCount) {


### PR DESCRIPTION
## Fix Quorum

Quorum = TotalVotingPower / TotalBindedTokens

Fixed a bug in the display that was dividing by the TotalSupply.

Cosmos SDK
```
	// If there is not enough quorum of votes, the proposal fails
	percentVoting := totalVotingPower.Quo(sdk.NewDecFromInt(keeper.sk.TotalBondedTokens(ctx)))
	quorum, _ := sdk.NewDecFromStr(params.Quorum)
	if percentVoting.LT(quorum) {
		return false, params.BurnVoteQuorum, tallyResults
	}
```