### PR TITLE
UYA Faster loading

### DIFF
--- a/projects/portal/src/app/models/band-protocols/band-protocol.service.ts
+++ b/projects/portal/src/app/models/band-protocols/band-protocol.service.ts
@@ -34,11 +34,11 @@ export class BandProtocolService {
     }
   }
 
-  async convertToUSDAmountDenom(
+  async convertToUSDAmount(
     denom: string,
     amount: string,
     denomMetadataMap: { [denom: string]: cosmosclient.proto.cosmos.bank.v1beta1.IMetadata },
-  ): Promise<TokenAmountUSD> {
+  ): Promise<number> {
     const symbol = denomMetadataMap[denom].symbol;
     const display = denomMetadataMap[denom].display;
     if (!symbol) {
@@ -51,11 +51,11 @@ export class BandProtocolService {
     const symbolAmount = Number(amount) / 10 ** (exponent || 0);
     const price = await this.getPrice(symbol);
     if (!price) {
-      return { symbol, display, symbolAmount };
+      return 0;
     }
 
     const usdAmount = symbolAmount * price;
-    return { symbol, display, symbolAmount, usdAmount };
+    return usdAmount;
   }
 
   calcDepositUSDAmount(

--- a/projects/portal/src/app/pages/yieldaggregator/vaults/deposit/deposit.component.html
+++ b/projects/portal/src/app/pages/yieldaggregator/vaults/deposit/deposit.component.html
@@ -5,5 +5,6 @@
   [vaults]="vaults$ | async"
   [symbols]="symbols$ | async"
   [usdDepositAmount]="usdDepositAmount$ | async"
+  [estimatedRedeemAmounts]="estimatedRedeemAmounts$ | async"
   [usdTotalAmount]="usdTotalAmount$ | async"
 ></view-deposit>

--- a/projects/portal/src/app/pages/yieldaggregator/vaults/vault/vault.component.html
+++ b/projects/portal/src/app/pages/yieldaggregator/vaults/vault/vault.component.html
@@ -10,6 +10,7 @@
   [withdrawReserve]="withdrawReserve$ | async"
   [estimatedMintAmount]="estimatedMintAmount$ | async"
   [estimatedRedeemAmount]="estimatedRedeemAmount$ | async"
+  [estimatedDepositedAmount]="estimatedDepositedAmount$ | async"
   [vaultBalance]="vaultBalance$ | async"
   [usdDepositAmount]="usdDepositAmount$ | async"
   [vaultInfo]="vaultInfo$ | async"

--- a/projects/portal/src/app/pages/yieldaggregator/vaults/vaults.component.html
+++ b/projects/portal/src/app/pages/yieldaggregator/vaults/vaults.component.html
@@ -3,7 +3,7 @@
   [vaults]="vaults$ | async"
   [symbols]="symbols$ | async"
   [vaultsInfo]="vaultsInfo$ | async"
-  [totalDeposited]="totalDeposited$ | async"
+  [totalDeposits]="totalDeposits$ | async"
   [keyword]="keyword$ | async"
   [sortType]="sortType$ | async"
   [certified]="certified$ | async"

--- a/projects/portal/src/app/pages/yieldaggregator/vaults/vaults.component.ts
+++ b/projects/portal/src/app/pages/yieldaggregator/vaults/vaults.component.ts
@@ -54,6 +54,15 @@ export class VaultsComponent implements OnInit {
         vaults.map((vault) => this.iyaService.calcVaultAPY(vault, config!, pools)),
       ),
     );
+    const vaultYieldMap$ = vaultYields$.pipe(
+      map((yields) => {
+        const yieldMap: { [id: string]: YieldInfo } = {};
+        for (const y of yields) {
+          yieldMap[y.id] = y;
+        }
+        return yieldMap;
+      }),
+    );
     const vaultDeposits$ = combineLatest([vaults$, denomMetadataMap$, symbolMetadataMap$]).pipe(
       mergeMap(([vaults, denomMetadataMap, symbolMetadataMap]) =>
         Promise.all(
@@ -161,11 +170,11 @@ export class VaultsComponent implements OnInit {
       }),
     );
     this.vaults$ = sortedVaults$;
-    this.vaultsInfo$ = combineLatest([this.vaults$, vaultYields$]).pipe(
-      map(([vaults, infos]) =>
+    this.vaultsInfo$ = combineLatest([this.vaults$, vaultYieldMap$]).pipe(
+      map(([vaults, map]) =>
         vaults.map(
           (vault) =>
-            infos.find((info) => info.id === vault.vault?.id) || {
+            map[vault.vault?.id!] || {
               id: vault.vault?.id!,
               minApy: 0,
               certainty: false,

--- a/projects/portal/src/app/views/yieldaggregator/vaults/deposit/deposit.component.html
+++ b/projects/portal/src/app/views/yieldaggregator/vaults/deposit/deposit.component.html
@@ -57,9 +57,13 @@
                   </td>
                   <td>{{ balance.amount | coinAmount }}</td>
                   <td>
-                    {{ usdDepositAmount?.[i]?.symbolAmount }} {{ usdDepositAmount?.[i]?.display }}
+                    {{
+                      estimatedRedeemAmounts?.[i]?.total_amount?.amount
+                        | coinAmount : estimatedRedeemAmounts?.[i]?.total_amount?.denom
+                    }}
+                    {{ symbols?.[i]?.display }}
                   </td>
-                  <td>{{ usdDepositAmount?.[i]?.usdAmount | currency }}</td>
+                  <td>{{ usdDepositAmount?.[i] | currency }}</td>
                 </tr>
               </ng-container>
             </tbody>

--- a/projects/portal/src/app/views/yieldaggregator/vaults/deposit/deposit.component.ts
+++ b/projects/portal/src/app/views/yieldaggregator/vaults/deposit/deposit.component.ts
@@ -1,7 +1,9 @@
 import { Component, Input, OnInit } from '@angular/core';
-import { TokenAmountUSD } from 'projects/portal/src/app/models/band-protocols/band-protocol.service';
 import { VaultBalance } from 'projects/portal/src/app/pages/yieldaggregator/vaults/deposit/deposit.component';
-import { VaultAll200ResponseVaultsInner } from 'ununifi-client/esm/openapi';
+import {
+  EstimateRedeemAmount200Response,
+  VaultAll200ResponseVaultsInner,
+} from 'ununifi-client/esm/openapi';
 
 @Component({
   selector: 'view-deposit',
@@ -14,7 +16,8 @@ export class DepositComponent implements OnInit {
   @Input() vaultBalances?: VaultBalance[] | null;
   @Input() vaults?: VaultAll200ResponseVaultsInner[] | null;
   @Input() symbols?: { symbol: string; display: string; img: string }[] | null;
-  @Input() usdDepositAmount?: TokenAmountUSD[] | null;
+  @Input() estimatedRedeemAmounts?: EstimateRedeemAmount200Response[] | null;
+  @Input() usdDepositAmount?: number[] | null;
   @Input() usdTotalAmount?: number | null;
 
   constructor() {}

--- a/projects/portal/src/app/views/yieldaggregator/vaults/vault/vault.component.html
+++ b/projects/portal/src/app/views/yieldaggregator/vaults/vault/vault.component.html
@@ -158,13 +158,13 @@
               <div class="animate-pulse bg-slate-700 w-32 h-12 rounded-full"></div>
             </div>
             <div class="stat-value text-info">
-              {{ totalDepositAmount?.usdAmount | currency }}
+              {{ totalDepositAmount | currency }}
             </div>
-            <div class="stat-value text-info" *ngIf="totalDepositAmount?.usdAmount === undefined">
+            <div class="stat-value text-info" *ngIf="totalDepositAmount === undefined">
               $ Unknown
             </div>
             <div class="stat-desc">
-              {{ totalDepositAmount?.symbolAmount | number : '1.0-2' }}
+              {{ calcVaultAmount(vault) | coinAmount : denom }}
               {{ denom | coinDenom | async }}
             </div>
           </div>
@@ -174,13 +174,11 @@
               <div class="animate-pulse bg-slate-700 w-32 h-12 rounded-full"></div>
             </div>
             <div class="stat-value text-info">
-              {{ usdDepositAmount?.usdAmount | currency }}
+              {{ usdDepositAmount | currency }}
             </div>
-            <div class="stat-value text-info" *ngIf="usdDepositAmount?.usdAmount === undefined">
-              $ Unknown
-            </div>
+            <div class="stat-value text-info" *ngIf="usdDepositAmount === undefined">$ Unknown</div>
             <div class="stat-desc">
-              {{ usdDepositAmount?.symbolAmount | number : '1.0-2' }}
+              {{ estimatedDepositedAmount?.total_amount?.amount | coinAmount }}
               {{ denom | coinDenom | async }}
             </div>
           </div>
@@ -192,13 +190,13 @@
               <div class="animate-pulse bg-slate-700 w-32 h-12 rounded-full"></div>
             </div>
             <div class="stat-value text-primary">
-              {{ totalBondedAmount?.usdAmount | currency }}
+              {{ totalBondedAmount | currency }}
             </div>
-            <div class="stat-value text-primary" *ngIf="totalBondedAmount?.usdAmount === undefined">
+            <div class="stat-value text-primary" *ngIf="totalBondedAmount === undefined">
               $ Unknown
             </div>
             <div class="stat-desc">
-              {{ totalBondedAmount?.symbolAmount | number : '1.0-2' }}
+              {{ vault?.total_bonded_amount | coinAmount : denom }}
               {{ denom | coinDenom | async }}
             </div>
           </div>
@@ -208,16 +206,13 @@
               <div class="animate-pulse bg-slate-700 w-32 h-12 rounded-full"></div>
             </div>
             <div class="stat-value text-secondary">
-              {{ totalUnbondingAmount?.usdAmount | currency }}
+              {{ totalUnbondingAmount | currency }}
             </div>
-            <div
-              class="stat-value text-secondary"
-              *ngIf="totalUnbondingAmount?.usdAmount === undefined"
-            >
+            <div class="stat-value text-secondary" *ngIf="totalUnbondingAmount === undefined">
               $ Unknown
             </div>
             <div class="stat-desc">
-              {{ totalUnbondingAmount?.symbolAmount | number : '1.0-2' }}
+              {{ vault?.total_unbonding_amount | coinAmount : denom }}
               {{ denom | coinDenom | async }}
             </div>
           </div>
@@ -227,13 +222,11 @@
               <div class="animate-pulse bg-slate-700 w-32 h-12 rounded-full"></div>
             </div>
             <div class="stat-value text-info">
-              {{ withdrawReserve?.usdAmount | currency }}
+              {{ withdrawReserve | currency }}
             </div>
-            <div class="stat-value text-info" *ngIf="withdrawReserve?.usdAmount === undefined">
-              $ Unknown
-            </div>
+            <div class="stat-value text-info" *ngIf="withdrawReserve === undefined">$ Unknown</div>
             <div class="stat-desc">
-              {{ withdrawReserve?.symbolAmount | number : '1.0-2' }} {{ denom | coinDenom | async }}
+              {{ vault?.withdraw_reserve | coinAmount : denom }} {{ denom | coinDenom | async }}
             </div>
           </div>
         </div>

--- a/projects/portal/src/app/views/yieldaggregator/vaults/vault/vault.component.ts
+++ b/projects/portal/src/app/views/yieldaggregator/vaults/vault/vault.component.ts
@@ -1,6 +1,5 @@
 import { Component, EventEmitter, Input, OnChanges, OnInit, Output } from '@angular/core';
 import cosmosclient from '@cosmos-client/core';
-import { TokenAmountUSD } from 'projects/portal/src/app/models/band-protocols/band-protocol.service';
 import { YieldInfo } from 'projects/portal/src/app/models/config.service';
 import {
   DepositToVaultRequest,
@@ -39,21 +38,23 @@ export class VaultComponent implements OnInit, OnChanges {
   @Input()
   denomMetadataMap?: { [denom: string]: cosmosclient.proto.cosmos.bank.v1beta1.IMetadata } | null;
   @Input()
-  totalDepositAmount?: TokenAmountUSD | null;
+  totalDepositAmount?: number | null;
   @Input()
-  totalBondedAmount?: TokenAmountUSD | null;
+  totalBondedAmount?: number | null;
   @Input()
-  totalUnbondingAmount?: TokenAmountUSD | null;
+  totalUnbondingAmount?: number | null;
   @Input()
-  withdrawReserve?: TokenAmountUSD | null;
+  withdrawReserve?: number | null;
   @Input()
   estimatedMintAmount?: EstimateMintAmount200Response | null;
   @Input()
   estimatedRedeemAmount?: EstimateRedeemAmount200Response | null;
   @Input()
+  estimatedDepositedAmount?: EstimateRedeemAmount200Response | null;
+  @Input()
   vaultBalance?: cosmosclient.proto.cosmos.base.v1beta1.ICoin | null;
   @Input()
-  usdDepositAmount?: TokenAmountUSD | null;
+  usdDepositAmount?: number | null;
   @Input()
   vaultInfo?: YieldInfo | null;
   @Input()
@@ -231,5 +232,16 @@ export class VaultComponent implements OnInit, OnChanges {
       Number(this.coinAmountPipe.transform(this.denomBalancesMap?.[denom].amount, denom)) * rate;
     this.burnAmount = Math.floor(this.burnAmount * Math.pow(10, 6)) / Math.pow(10, 6);
     this.onWithdrawAmountChange();
+  }
+
+  calcVaultAmount(vault?: Vault200Response | null): string {
+    if (!vault) {
+      return '0';
+    }
+    return (
+      Number(vault.total_bonded_amount) +
+      Number(vault.total_unbonding_amount) +
+      Number(vault.withdraw_reserve)
+    ).toString();
   }
 }

--- a/projects/portal/src/app/views/yieldaggregator/vaults/vaults.component.html
+++ b/projects/portal/src/app/views/yieldaggregator/vaults/vaults.component.html
@@ -197,9 +197,9 @@
                   <td>
                     <div
                       class="animate-pulse bg-slate-700 w-12 h-6 rounded-full"
-                      *ngIf="totalDeposited === null"
+                      *ngIf="totalDeposits === null"
                     ></div>
-                    {{ totalDeposited?.[i]?.usdAmount | currency }}
+                    {{ totalDeposits?.[i] | currency }}
                   </td>
                 </tr>
               </ng-container>

--- a/projects/portal/src/app/views/yieldaggregator/vaults/vaults.component.ts
+++ b/projects/portal/src/app/views/yieldaggregator/vaults/vaults.component.ts
@@ -19,7 +19,7 @@ export class VaultsComponent implements OnInit {
   @Input()
   vaultsInfo?: YieldInfo[] | null;
   @Input()
-  totalDeposited?: TokenAmountUSD[] | null;
+  totalDeposits?: number[] | null;
   @Input()
   keyword?: string | null;
   @Input()
@@ -42,6 +42,10 @@ export class VaultsComponent implements OnInit {
   }
 
   onSort(sortType: string) {
+    // reset sort
+    if (this.sortType === sortType) {
+      sortType = 'id';
+    }
     this.sort.emit(sortType);
   }
 

--- a/projects/portal/src/app/views/yieldaggregator/vaults/vaults.component.ts
+++ b/projects/portal/src/app/views/yieldaggregator/vaults/vaults.component.ts
@@ -1,4 +1,3 @@
-import { TokenAmountUSD } from '../../../models/band-protocols/band-protocol.service';
 import { YieldInfo } from '../../../models/config.service';
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { Router } from '@angular/router';


### PR DESCRIPTION
Speeds up loading by reducing the number of APIs to kick when loading the Vault List.

- before
Each of the Osmosis and Oracle APIs were executed in a number of vaults.

- after
The Osmosis API is executed only once. 
Oracle API is executed as many times as the number of tokens present in the vault.