### PR TITLE
PT (YT & LP) name change

### DIFF
--- a/projects/portal/editions/ununifi/launch/gluon-beta/firebase-hosting/config.js
+++ b/projects/portal/editions/ununifi/launch/gluon-beta/firebase-hosting/config.js
@@ -101,6 +101,21 @@ const denomMetadata = [
     symbol: 'USDC',
   },
   {
+    description: 'The governance token of CosmosHub  ATOM',
+    denom_units: [
+      {
+        denom: 'uatom',
+        exponent: 0,
+        aliases: [],
+      },
+
+    ],
+    base: 'uatom',
+    display: 'ATOM',
+    name: 'ATOM (Cosmos)',
+    symbol: 'ATOM',
+  },
+  {
     description: 'Stablecoin pegged to ATOM',
     denom_units: [
       {

--- a/projects/portal/src/app/views/interest-rate-swap/pools/pool/pool.component.html
+++ b/projects/portal/src/app/views/interest-rate-swap/pools/pool/pool.component.html
@@ -136,7 +136,7 @@
                         </div>
                       </div>
                     </div>
-                    <div>PT {{ vault?.name }}#{{ poolId }}</div>
+                    <div>PT {{ vault?.denom | coinDenom | async }}#{{ poolId }}</div>
                   </span>
                   <input
                     #depositPtAmountNgModelRef="ngModel"
@@ -192,7 +192,7 @@
                       </div>
                     </div>
                   </div>
-                  <div>LP {{ vault?.name }}#{{ poolId }}</div>
+                  <div>LP {{ vault?.denom | coinDenom | async }}#{{ poolId }}</div>
                 </span>
                 <input
                   class="join-item input input-bordered w-full"
@@ -230,7 +230,7 @@
                         </div>
                       </div>
                     </div>
-                    <div>LP {{ vault?.name }}#{{ poolId }}</div>
+                    <div>LP {{ vault?.denom | coinDenom | async }}#{{ poolId }}</div>
                   </span>
                   <input
                     #withdrawAmountNgModelRef="ngModel"
@@ -311,7 +311,7 @@
                       </div>
                     </div>
                   </div>
-                  <div>PT {{ vault?.name }}#{{ poolId }}</div>
+                  <div>PT {{ vault?.denom | coinDenom | async }}#{{ poolId }}</div>
                 </span>
                 <input
                   class="join-item input input-bordered w-full"

--- a/projects/portal/src/app/views/interest-rate-swap/vaults/vault/vault.component.html
+++ b/projects/portal/src/app/views/interest-rate-swap/vaults/vault/vault.component.html
@@ -152,7 +152,9 @@
                       </div>
                     </div>
                   </div>
-                  <div>{{ swapTab | uppercase }} {{ vault?.name }}#{{ trancheId }}</div>
+                  <div>
+                    {{ swapTab | uppercase }} {{ vault?.denom | coinDenom | async }}#{{ trancheId }}
+                  </div>
                 </span>
                 <input
                   *ngIf="swapTab === 'pt'"
@@ -312,7 +314,11 @@
                         </div>
                       </div>
                     </div>
-                    <div>{{ swapTab | uppercase }} {{ vault?.name }}#{{ trancheId }}</div>
+                    <div>
+                      {{ swapTab | uppercase }} {{ vault?.denom | coinDenom | async }}#{{
+                        trancheId
+                      }}
+                    </div>
                   </span>
                   <input
                     *ngIf="swapTab === 'pt'"
@@ -537,7 +543,7 @@
                       </div>
                     </div>
                   </div>
-                  <div>PT {{ vault?.name }}#{{ trancheId }}</div>
+                  <div>PT {{ vault?.denom | coinDenom | async }}#{{ trancheId }}</div>
                 </span>
                 <input
                   class="join-item input input-bordered w-full"
@@ -557,7 +563,7 @@
                       </div>
                     </div>
                   </div>
-                  <div>YT {{ vault?.name }}#{{ trancheId }}</div>
+                  <div>YT {{ vault?.denom | coinDenom | async }}#{{ trancheId }}</div>
                 </span>
                 <input
                   class="join-item input input-bordered w-full"
@@ -654,7 +660,7 @@
                         </div>
                       </div>
                     </div>
-                    <div>PT {{ vault?.name }}#{{ trancheId }}</div>
+                    <div>PT {{ vault?.denom | coinDenom | async }}#{{ trancheId }}</div>
                   </span>
                   <input
                     #pairPtAmountNgModelRef="ngModel"
@@ -705,7 +711,7 @@
                         </div>
                       </div>
                     </div>
-                    <div>YT {{ vault?.name }}#{{ trancheId }}</div>
+                    <div>YT {{ vault?.denom | coinDenom | async }}#{{ trancheId }}</div>
                   </span>
                   <input
                     #pairYtAmountNgModelRef="ngModel"
@@ -825,7 +831,7 @@
               </div>
               <div class="mr-4">
                 <div class="text-xl font-bold">
-                  {{ swapTab | uppercase }} {{ vault?.name }}#{{ trancheId }}
+                  {{ swapTab | uppercase }} {{ vault?.denom | coinDenom | async }}#{{ trancheId }}
                 </div>
                 <div class="text-sm opacity-50"></div>
               </div>


### PR DESCRIPTION
`PT {{vault_underlying_token}} #{{tranche_id}}`
![スクリーンショット 2024-03-27 113023](https://github.com/UnUniFi/web-apps/assets/29295263/cd78ab66-59f2-4227-8c4c-93aada427d9d)

The balance page is unable to get the vault information due to technical difficulties and simply shows `PT #{{tranche_id}}`

It is quite difficult to get `vault_underlying_token`, because we can only get the denom irs/tranche/1/pt from the balance query, so we need to do some looping to get the vault information from here.
I'll add a query to the backend and address it in a future update.
![スクリーンショット 2024-03-27 113040](https://github.com/UnUniFi/web-apps/assets/29295263/6ab92280-bb3a-4128-a3af-2bf36ea281f4)
